### PR TITLE
Fix typo in documentation

### DIFF
--- a/man/BIOMOD.EnsembleModeling.out-class.Rd
+++ b/man/BIOMOD.EnsembleModeling.out-class.Rd
@@ -12,7 +12,7 @@
 \title{ BIOMOD_EnsembleModeling() outputs objects class}
 
 \description{
-EnsembleModeling objects are created, used and returned by BIOMOD functions. It's contains information relative to an \pkg{biomod2} ensemble modeling procedure. 
+EnsembleModeling objects are created, used and returned by BIOMOD functions. It's contains information relative to an \pkg{biomod2} ensemble modeling procedure.
 
 \itemize{
   \item{output of: }{\code{\link[biomod2]{BIOMOD_EnsembleModeling}}}
@@ -27,13 +27,13 @@ EnsembleModeling objects are created, used and returned by BIOMOD functions. It'
     \item{\code{sp.name}:}{ "character", species name }
     \item{\code{expl.var.names}:}{ "character", explanatory variables names }
     \item{\code{models.out.obj}:}{"BIOMOD.stored.models.out", object which contains information on individuals models that have been combined}
-    \item{\code{eval.metric}:}{ "character", evaluation metrics choosed for models selection }
+    \item{\code{eval.metric}:}{ "character", evaluation metrics chose for models selection }
     \item{\code{eval.metric.quality.threshold}:}{ "numeric", thresholds defined for models selection }
     \item{\code{em.computed}:}{ "character", ensemble models built names}
     \item{\code{em.by}:}{ "character", way models are combined}
     \item{\code{em.models}:}{ "ANY", list of built biomod2.ensemble.models objects }
     \item{\code{modeling.id}:}{ "character", the id of the whole modelling process}
-    \item{\code{link}:}{ "character", the path to correspunding hard drive saved object}
+    \item{\code{link}:}{ "character", the path to corresponding hard drive saved object}
   }
 
 }

--- a/man/BIOMOD.EnsembleModeling.out-methods.Rd
+++ b/man/BIOMOD.EnsembleModeling.out-methods.Rd
@@ -48,7 +48,7 @@ Functions to get attributes of \code{\link[biomod2]{BIOMOD_EnsembleModeling}} ou
 
     \item{\bold{get_kept_models}}{
       \itemize{
-        \item{model}{"character" or "numeric" refering to model names (get_built_models()) or model id }
+        \item{model}{"character" or "numeric" referring to model names (get_built_models()) or model id }
       }
     }
 

--- a/man/BIOMOD.EnsembleModeling.out-methods.Rd
+++ b/man/BIOMOD.EnsembleModeling.out-methods.Rd
@@ -11,8 +11,8 @@
 
 \title{ BIOMOD.EnsembleModeling.out getters }
 
-\description{ 
-Functions to get attributs of \code{\link[biomod2]{BIOMOD_EnsembleModeling}} outputs
+\description{
+Functions to get attributes of \code{\link[biomod2]{BIOMOD_EnsembleModeling}} outputs
 }
 
 \usage{
@@ -36,24 +36,24 @@ Functions to get attributs of \code{\link[biomod2]{BIOMOD_EnsembleModeling}} out
 
 \details{
 
-  \ldots{ } available values : 
-  
+  \ldots{ } available values :
+
   \itemize{
-  
+
     \item{\bold{get_evaluations}}{
       \itemize{
         \item{\code{as.data.frame}:}{"logical", ( FALSE by default ) if TRUE, a standardized \code{data.frame} will be produced else a list is returned }
       }
     }
-    
+
     \item{\bold{get_kept_models}}{
       \itemize{
         \item{model}{"character" or "numeric" refering to model names (get_built_models()) or model id }
       }
     }
-    
-    
-  } 
+
+
+  }
 }
 
 
@@ -61,15 +61,15 @@ Functions to get attributs of \code{\link[biomod2]{BIOMOD_EnsembleModeling}} out
 
   \enumerate{
     \item{\bold{get_built_models: }}{ a \code{character} vector indicating set of ensemble-modeling algorithms ran}
-    
+
     \item{\bold{get_built_models: }}{ a \code{character} vector indicating the names of ensemble models computed }
-    
+
     \item{\bold{get_evaluations: }}{ an \code{array}, a \code{data.frame} or a \code{list} containing ensemble models evaluation scores}
-    
+
     \item{\bold{get_kept_models: }}{ an \code{character} vector indicating names of selected models for ensemble-models building}
-    
+
     \item{\bold{get_needed_models: }}{ an \code{character} vector indicating names of all needed models required to build all ensemble-models}
-    
+
   }
 }
 

--- a/man/BIOMOD.Model.Options-class.Rd
+++ b/man/BIOMOD.Model.Options-class.Rd
@@ -10,7 +10,7 @@
 \title{ BIOMOD_ModelingOptions() outputs objects class}
 
 \description{
-BIOMOD.Model.Options objects are created, used and returned by BIOMOD functions. These objects will contains for each model support within \pkg{biomod2}, a set of options that users can change. Please refer to \code{\link[biomod2]{BIOMOD_ModelingOptions}} for futher details. 
+BIOMOD.Model.Options objects are created, used and returned by BIOMOD functions. These objects will contains for each model support within \pkg{biomod2}, a set of options that users can change. Please refer to \code{\link[biomod2]{BIOMOD_ModelingOptions}} for further details. 
 
 \itemize{
   \item{output of: }{\code{\link[biomod2]{BIOMOD_ModelingOptions}}}

--- a/man/BIOMOD.formated.data-class.Rd
+++ b/man/BIOMOD.formated.data-class.Rd
@@ -21,7 +21,7 @@
 \title{ BIOMOD_FormatingData() outputs objects class}
 
 \description{
-BIOMOD.formated.data objects are created, used and returned by BIOMOD functions. It's contains the minimal set of data \pkg{biomod2} needs to work. Input data given to \code{\link[biomod2]{BIOMOD_FormatingData}} are rearanged to fit with \code{\link[biomod2]{BIOMOD_Modeling}} input format. All data are stored into matrix (even environemental raster) explaining why some objects appears to be quite heavy.
+BIOMOD.formated.data objects are created, used and returned by BIOMOD functions. It's contains the minimal set of data \pkg{biomod2} needs to work. Input data given to \code{\link[biomod2]{BIOMOD_FormatingData}} are rearranged to fit with \code{\link[biomod2]{BIOMOD_Modeling}} input format. All data are stored into matrix (even environmental raster) explaining why some objects appears to be quite heavy.
 
 If you ask for pseudo absences selection in \code{\link[biomod2]{BIOMOD_FormatingData}}, you will get a \code{BIOMOD.formated.data.PA}, else you will get a \code{BIOMOD.formated.data.PA} object.
 

--- a/man/BIOMOD.models.out-class.Rd
+++ b/man/BIOMOD.models.out-class.Rd
@@ -32,7 +32,7 @@ BIOMOD.models.out objects
     \item{\code{models.computed}:}{ "character", names of computed models }
     \item{\code{models.failed}:}{ "character", names of failed models }
     \item{\code{models.evaluation}:}{ "BIOMOD.stored.array", evaluations of each model computed according to selected evaluation methods }
-    \item{\code{variables.importances}:}{ "BIOMOD.stored.array", models variable importances }
+    \item{\code{variables.importances}:}{ "BIOMOD.stored.array", models variable importance }
     \item{\code{models.prediction}:}{ "BIOMOD.stored.array", predictions of each models on their own calibration + validation dataset }
     \item{\code{models.prediction.eval}:}{ "BIOMOD.stored.array", predictions of each models on evaluation dataset (if defined) }
     \item{\code{formated.input.data}:}{ "BIOMOD.stored.formated.data", input data }

--- a/man/BIOMOD.models.out-methods.Rd
+++ b/man/BIOMOD.models.out-methods.Rd
@@ -53,7 +53,7 @@ Functions to get attributes of \code{\link[biomod2]{BIOMOD_Modeling}} outputs
 
     \item{\bold{get_evaluations}}{
       \itemize{
-        \item{\code{as.data.frame}:}{"logical", ( FALSE by default ) if TRUE, a standardized \code{data.frame} will be produced else an 4 dimentions \code{array} is returned }
+        \item{\code{as.data.frame}:}{"logical", ( FALSE by default ) if TRUE, a standardized \code{data.frame} will be produced else a 4-dimension \code{array} is returned }
       }
     }
 
@@ -91,18 +91,18 @@ Functions to get attributes of \code{\link[biomod2]{BIOMOD_Modeling}} outputs
   \enumerate{
     \item{\bold{get_predictions: }}{ an \code{array} (or a \code{data.frame}) containing models predictions over calibrating and testing data (those used for evaluate models)}
 
-    \item{\bold{get_calib_lines: }}{ an \code{array} (or a \code{data.frame}) having the same dimention than the outpurt of \bold{get_predictions()} of logical values. All lines containing TRUE have been used to calibrate the model}
+    \item{\bold{get_calib_lines: }}{ an \code{array} (or a \code{data.frame}) having the same dimension than the output of \bold{get_predictions()} of logical values. All lines containing TRUE have been used to calibrate the model}
 
     \item{\bold{get_evaluations: }}{ an \code{array}, a \code{data.frame} or a \code{list} containing models evaluation scores}
 
 
-    \item{\bold{get_variables_importance: }}{ an \code{array} containing models variables importances}
+    \item{\bold{get_variables_importance: }}{ an \code{array} containing models variables importance}
 
     \item{\bold{get_options: }}{ a \code{"\link[=BIOMOD.Model.Options-class]{BIOMOD.Model.Options}"} reporting options used to build individual models}
 
-    \item{\bold{get_formal_data: }}{a \code{"\link[=BIOMOD.formated.data-class]{BIOMOD.formated.data}"} object containing data used for models building and evavaluation, or a part of this object}
+    \item{\bold{get_formal_data: }}{a \code{"\link[=BIOMOD.formated.data-class]{BIOMOD.formated.data}"} object containing data used for models building and evaluation, or a part of this object}
 
-    \item{\bold{get_built_models: }}{a character vector giving the names of models succefully computed}
+    \item{\bold{get_built_models: }}{a character vector giving the names of models successfully computed}
 
   }
 }

--- a/man/BIOMOD.models.out-methods.Rd
+++ b/man/BIOMOD.models.out-methods.Rd
@@ -24,8 +24,8 @@
 
 \title{ BIOMOD.models.out getters }
 
-\description{ 
-Functions to get attributs of \code{\link[biomod2]{BIOMOD_Modeling}} outputs
+\description{
+Functions to get attributes of \code{\link[biomod2]{BIOMOD_Modeling}} outputs
 }
 
 \usage{
@@ -47,8 +47,8 @@ Functions to get attributs of \code{\link[biomod2]{BIOMOD_Modeling}} outputs
 
 \details{
 
-  \ldots{ } available values : 
-  
+  \ldots{ } available values :
+
   \itemize{
 
     \item{\bold{get_evaluations}}{
@@ -56,16 +56,16 @@ Functions to get attributs of \code{\link[biomod2]{BIOMOD_Modeling}} outputs
         \item{\code{as.data.frame}:}{"logical", ( FALSE by default ) if TRUE, a standardized \code{data.frame} will be produced else an 4 dimentions \code{array} is returned }
       }
     }
-    
+
     \item{\bold{get_calib_lines}}{
     }
-  
+
     \item{\bold{get_predictions (for BIOMOD_Modeling() outputs only)}}{
       \itemize{
         \item{\code{as.data.frame}:}{logical(default FALSE). If TRUE, models predictions will be returned as \code{data.frame} rather than \code{array}}
         \item{\code{evaluation}:}{logical (default FALSE). If TRUE, model prediction over evaluation data will be returned }}
     }
-    
+
     \item{\bold{get_formal_data}}{
       \itemize{
         \item{\code{subinfo}:}{character. Flag defining a specific information to extract from \code{"\link[=BIOMOD.formated.data-class]{BIOMOD.formated.data}"} object. Supported values are: }
@@ -77,8 +77,8 @@ Functions to get attributs of \code{\link[biomod2]{BIOMOD_Modeling}} outputs
             \item{\code{'expl.var'}:}{ Explanatory variables \code{data.frame} returned}
             \item{\code{'eval.expl.var'}:}{ Evaluation explanatory variables \code{data.frame} returned}
             \item{\code{'expl.var.names'}:}{ Explanatory variables names returned}
-            
-            
+
+
           }
       }
     }
@@ -92,18 +92,18 @@ Functions to get attributs of \code{\link[biomod2]{BIOMOD_Modeling}} outputs
     \item{\bold{get_predictions: }}{ an \code{array} (or a \code{data.frame}) containing models predictions over calibrating and testing data (those used for evaluate models)}
 
     \item{\bold{get_calib_lines: }}{ an \code{array} (or a \code{data.frame}) having the same dimention than the outpurt of \bold{get_predictions()} of logical values. All lines containing TRUE have been used to calibrate the model}
-    
+
     \item{\bold{get_evaluations: }}{ an \code{array}, a \code{data.frame} or a \code{list} containing models evaluation scores}
-    
-    
+
+
     \item{\bold{get_variables_importance: }}{ an \code{array} containing models variables importances}
-    
+
     \item{\bold{get_options: }}{ a \code{"\link[=BIOMOD.Model.Options-class]{BIOMOD.Model.Options}"} reporting options used to build individual models}
-    
+
     \item{\bold{get_formal_data: }}{a \code{"\link[=BIOMOD.formated.data-class]{BIOMOD.formated.data}"} object containing data used for models building and evavaluation, or a part of this object}
-    
-    \item{\bold{get_built_models: }}{a character vector giving the names of models succefully computed} 
-  
+
+    \item{\bold{get_built_models: }}{a character vector giving the names of models succefully computed}
+
   }
 }
 

--- a/man/BIOMOD.projection.out-methods.Rd
+++ b/man/BIOMOD.projection.out-methods.Rd
@@ -9,8 +9,8 @@
 
 \title{ BIOMOD.projection.out getters }
 
-\description{ 
-Functions to get attributs of \code{\link[biomod2]{BIOMOD_Projection}} outputs
+\description{
+Functions to get attributes of \code{\link[biomod2]{BIOMOD_Projection}} outputs
 }
 
 \usage{
@@ -32,8 +32,8 @@ Functions to get attributs of \code{\link[biomod2]{BIOMOD_Projection}} outputs
 
 \details{
 
-  \ldots{ } available values : 
-  
+  \ldots{ } available values :
+
   \itemize{
     \item{get_predictions}
     \itemize{
@@ -42,7 +42,7 @@ Functions to get attributs of \code{\link[biomod2]{BIOMOD_Projection}} outputs
       \item{\code{model}:}{NULL or "character", \emph{type name} of models you want to extract projections }
       \item{\code{run.eval}:}{NULL or "character", \emph{run name} of models you want to extract projections }
       \item{\code{data.set}:}{NULL or "character", \emph{dataset name} of models you want to extract projections }
-      
+
     }
   }
 }
@@ -53,7 +53,7 @@ Functions to get attributs of \code{\link[biomod2]{BIOMOD_Projection}} outputs
   \enumerate{
     \item{\bold{get_predictions: }}{ an \code{array} or a \code{data.frame} containing models projections}
     \item{\bold{get_projected_models: }}{ \code{character} containing names of models that have been projected}
-    \item{\bold{free: }}{remove projection value from R memory and only keep the path to correspunding file on hard drive.}
+    \item{\bold{free: }}{remove projection value from R memory and only keep the path to corresponding file on hard drive.}
   }
 }
 

--- a/man/BIOMOD.stored.objects-methods.Rd
+++ b/man/BIOMOD.stored.objects-methods.Rd
@@ -5,8 +5,8 @@
 
 \title{BIOMOD.stored.objects functions}
 
-\description{ 
-Functions to play with attributs of \code{BIOMOD.stored.objects} objects
+\description{
+Functions to play with attributes of \code{BIOMOD.stored.objects} objects
 }
 
 \usage{

--- a/man/BIOMOD_EnsembleForecasting.Rd
+++ b/man/BIOMOD_EnsembleForecasting.Rd
@@ -24,7 +24,7 @@ BIOMOD_EnsembleForecasting( EM.output,
   \item{projection.output}{a \code{"\link[=BIOMOD.projection.out-class]{BIOMOD.projection.out}"} returned by \code{\link[biomod2]{BIOMOD_Projection}} }
   \item{new.env}{ a \code{RasterStack} or a \code{data.frame} object containing explanatory data for the studied area. Needed only if \code{projection.output} is \code{NULL}. Prefer to use \code{"\link[=BIOMOD.projection.out-class]{BIOMOD.projection.out}"} if you have ever done the calculations.}
   \item{xy.new.env}{the matching coordinates of \code{new.env} if \code{new.env} is defined and if it is a \code{data.frame}}
-  \item{selected.models}{ if not 'all', a character vector containing a subset of ensemble-models you want make projacion}
+  \item{selected.models}{ if not 'all', a character vector containing a subset of ensemble-models you want make projection}
   \item{proj.name}{the projection name (results will be saved within proj_proj.name directory). Only needed if \code{projection.output} is \code{NULL} }
   \item{binary.meth}{vector specifying the names of evaluation metrics and associated thresholds to transform the probabilities of presence into presence and absence (binary transformation).  }
   \item{filtered.meth}{vector specifying the names of evaluation metrics and associated thresholds to transform into 0 the probabilities of presence lower than the thresholds.}

--- a/man/BIOMOD_EnsembleModeling.Rd
+++ b/man/BIOMOD_EnsembleModeling.Rd
@@ -35,7 +35,7 @@ BIOMOD_EnsembleModeling( modeling.output,
   \item{prob.cv}{Logical. Estimate the coefficient of variation across predictions}
   \item{prob.ci}{Logical . Estimate the confidence interval around the \code{prob.mean}}
   \item{prob.ci.alpha}{Numeric. Significance level for estimating the confidence interval. Default = 0.05}
-  \item{prob.median}{Logical. Estimate the mediane of probabilities}
+  \item{prob.median}{Logical. Estimate the median of probabilities}
   \item{committee.averaging}{Logical. Estimate the committee averaging across predictions}
   \item{prob.mean.weight}{Logical. Estimate the weighted sum of probabilities}
   \item{prob.mean.weight.decay}{Define the relative importance of the weights. A high value will strongly discriminate the 'good' models from the 'bad' ones (see the details section). If the value of this parameter is set to 'proportional' (default), then the attributed weights are proportional to the evaluation scores given by 'weight.method'(\code{eval.metric})}
@@ -132,7 +132,7 @@ BIOMOD_EnsembleModeling( modeling.output,
           The \code{prob.mean.weight.decay} is the ratio between a weight and the following or prior one. The formula is : W = W(-1) * \code{prob.mean.weight.decay}. For example, with the value of 1.6 and 4 weights wanted, the relative importance of the weights will be 1 /1.6/2.56(=1.6*1.6)/4.096(=2.56*1.6) from the weakest to the strongest, and gives 0.11/0.17/0.275/0.445 considering that the sum of the weights is equal to one. The lower the \code{prob.mean.weight.decay}, the smoother the differences between the weights enhancing a weak discrimination between models.
 
           The value 'proportional' (default) is also possible for the \code{prob.mean.weight.decay}: the weights are awarded for each method proportionally to their evaluation scores. The advantage is that the discrimination is more fair than with the \code{prob.mean.weight.decay}. In the latter case, close scores can strongly diverge in the weights they are awarded, when the proportional method will consider them as being fairly similar in prediction quality and award them a similar weight.
-          It is also possible to define a function as \code{prob.mean.weight.decay} argument. In this case the given function will be applied to models scores to transforme them into weights that will be used for wheigted mean ensemble model building. For instance if you specified \code{ function(x){x^2} } as \code{prob.mean.weight.decay}, the squared of evaluation score of each model will be used to weight formal models predictions.
+          It is also possible to define a function as \code{prob.mean.weight.decay} argument. In this case the given function will be applied to models scores to transform them into weights that will be used for weighted mean ensemble model building. For instance if you specified \code{ function(x){x^2} } as \code{prob.mean.weight.decay}, the squared of evaluation score of each model will be used to weight formal models predictions.
         }
 
       }

--- a/man/BIOMOD_EnsembleModeling.Rd
+++ b/man/BIOMOD_EnsembleModeling.Rd
@@ -3,7 +3,7 @@
 
 \title{ Create and evaluate an ensemble set of models and predictions}
 \description{
-\code{BIOMOD_EnsembleModeling} combines models and make ensemble predictions built with \code{\link[biomod2]{BIOMOD_Modeling}}. The ensemble predictions can also be evaluated against the original data given to  \code{\link[biomod2]{BIOMOD_Modeling}}. Biomod2 proposes a range of options to build ensemble models and predictions and to assess the modeling uncertainty. The created ensemble models can then be used to project distributions over space and time as classical \pkg{biomod2} models. 
+\code{BIOMOD_EnsembleModeling} combines models and make ensemble predictions built with \code{\link[biomod2]{BIOMOD_Modeling}}. The ensemble predictions can also be evaluated against the original data given to  \code{\link[biomod2]{BIOMOD_Modeling}}. Biomod2 proposes a range of options to build ensemble models and predictions and to assess the modeling uncertainty. The created ensemble models can then be used to project distributions over space and time as classical \pkg{biomod2} models.
 }
 
 \usage{
@@ -28,7 +28,7 @@ BIOMOD_EnsembleModeling( modeling.output,
   \item{modeling.output}{a \code{"\link[=BIOMOD.models.out-class]{BIOMOD.models.out}"} returned by \code{\link[biomod2]{BIOMOD_Modeling}}}
   \item{chosen.models}{a character vector (either 'all' or a sub-selection of model names) that defines the models kept for building the ensemble models (might be useful for removing some non-preferred models)}
   \item{em.by}{Character. Flag defining the way the models will be combined to build the ensemble models. Available values are \code{'PA_dataset+repet'} (default), \code{'PA_dataset+algo'}, \code{'PA_dataset'}, \code{'algo'} and  \code{'all'}}
-  \item{eval.metric}{vector of names of evaluation metric used to build ensemble models. It is involved for formal models exclusion if \code{eval.metric.quality.threshold} is defined and/or for building ensemble models that are dependent of formal models evaluation scores (e.g. weighted mean and comitee averaging). If 'all', the same evaluation metrics than those of \code{modeling.output} will be automatically selected}
+  \item{eval.metric}{vector of names of evaluation metric used to build ensemble models. It is involved for formal models exclusion if \code{eval.metric.quality.threshold} is defined and/or for building ensemble models that are dependent of formal models evaluation scores (e.g. weighted mean and committee averaging). If 'all', the same evaluation metrics than those of \code{modeling.output} will be automatically selected}
   \item{eval.metric.quality.threshold}{If not \code{NULL}, the minimum scores below which models will be excluded of the ensemble-models building.}
   \item{models.eval.meth}{ the evaluation methods used to evaluate ensemble models ( see \code{"\link[=BIOMOD_Modeling]{BIOMOD_Modeling}"}  \bold{models.eval.meth} section for more detailed informations )}
   \item{prob.mean}{Logical. Estimate the mean probabilities across predictions }
@@ -43,15 +43,15 @@ BIOMOD_EnsembleModeling( modeling.output,
 }
 
 \details{
-  \enumerate{ 
+  \enumerate{
     \item{\bold{Models sub-selection (\code{chosen.models})}}{
 
       Useful to exclude some models that have been selected in the previous steps (\code{modeling.output}). This vector of model names can be access applying \code{get_built_models} to your \code{modeling.output} data. It makes easier the selection of models. The default value (i.e. \sQuote{all}) will kept all available models.}
-    
+
     \item{\bold{Models assembly rules (\code{em.by})}}{
-    
+
     Please refer to \href{../doc/EnsembleModelingAssembly.pdf}{EnsembleModelingAssembly} vignette that is dedicated to this parameter.
-    
+
       5 different ways to combine models can be considered. You can make ensemble models considering :
       \itemize{
         \item{ Dataset used for models building (Pseudo Absences dataset and repetitions done)}{: \code{'PA_dataset+repet'}}
@@ -60,87 +60,87 @@ BIOMOD_EnsembleModeling( modeling.output,
         \item{ Statistical models }{: \code{'algo'}}
         \item{ A total consensus model  }{: \code{'all'}}
       }
-      
+
       The value chosen for this parameter will control the number of ensemble models built.
       If no evaluation data was given the at \code{\link[biomod2]{BIOMOD_FormatingData}} step, some ensemble models evaluation may be a bit unfair because the data that will be used for evaluating ensemble models could differ from those used for evaluate \code{\link[biomod2]{BIOMOD_Modeling}} models (in particular, some data used for 'basal models' calibration can be re-used for ensemble models evaluation). You have to keep it in mind ! (\href{../doc/EnsembleModelingAssembly.pdf}{EnsembleModelingAssembly} vignette for extra details)
     }
-    
+
     \item{\bold{Evaluation metrics}}{
       \itemize{
         \item{\bold{\code{eval.metric}}}{
-    
+
           The selected metrics here are necessary the ones chosen at the \code{\link[biomod2]{BIOMOD_Modeling}} step.
           If you select several, ensembles will be built according to each of them.
-          The chosen metrics will be used at different stages in this function : 
+          The chosen metrics will be used at different stages in this function :
           \enumerate{
             \item{to remove \sQuote{bad models} (having a score lower than \code{eval.metric.quality.threshold} (see bellow))}
             \item{to make the binary transformation needed for committee averaging computation}
             \item{to weight the models in the probability weighted mean model}
             \item{to test (and/or evaluate) your ensemble-models forecasting ability (at this step, each ensemble-model (ensemble will be evaluated according to each evaluation metric)}
-          } % end of enumerate 
+          } % end of enumerate
         }
-      
-      
+
+
         \item{\bold{\code{eval.metric.quality.threshold}}}{
-        
+
           You have to give as many threshold as \code{eval.metric} you have selected.  If you have selected  several evaluation metrics , take care to ensure that the order of thresholds matches the order of \code{eval.metric}.
           All models having a score lower than these quality thresholds will not be kept for building ensemble-models.
         }
       }
     }
-    
+
     \item{\bold{Ensemble-models algorithms}}{
       \enumerate{
         \item{\bold{Mean of probabilities (\code{prob.mean}) }}{
-        
+
           This ensemble-model corresponds to the mean probabilities over the selected models.
         }
-        
+
         \item{\bold{Coefficient of variation of Probabilities (\code{prob.cv}) }}{
-        
-          This ensemble-model corresponds to the coefficient of variation (i.e. sd / mean) of the probabilities over the selected models. This model is not scaled. It will be evaluated like all other ensemble-models although this interpretation is obviously different. CV is a measure of uncertainty rather a measure of probability of occurrence. If the CV gets a high evaluation score it means that the uncertainty is high where the species is observed (which might not be a good feature of the models). The lower is the score, the better are the models. CV is a nice complement to the mean probability. 
+
+          This ensemble-model corresponds to the coefficient of variation (i.e. sd / mean) of the probabilities over the selected models. This model is not scaled. It will be evaluated like all other ensemble-models although this interpretation is obviously different. CV is a measure of uncertainty rather a measure of probability of occurrence. If the CV gets a high evaluation score it means that the uncertainty is high where the species is observed (which might not be a good feature of the models). The lower is the score, the better are the models. CV is a nice complement to the mean probability.
         }
-      
+
         \item{\bold{Confidence interval (\code{prob.ci} & \code{prob.ci.alpha}) }}{
-         This is the confidence interval around the mean probability (see above). This is also a nice complement to the mean probability. 
-          Two ensemble-models will be built if \code{prob.ci} is \code{TRUE} : 
+         This is the confidence interval around the mean probability (see above). This is also a nice complement to the mean probability.
+          Two ensemble-models will be built if \code{prob.ci} is \code{TRUE} :
           \itemize{
             \item{The upper one (there is less than a 100*\code{prob.ci.alpha}/2 \% of chance to get probabilities upper than the given ones)}
                         \item{The lower one (there is less than a 100*\code{prob.ci.alpha}/2 \% of chance to get probabilities lower the than given ones)}
           }
           These intervals are calculated with the following function :
-          
+
           \deqn{
             I_c = [ \bar{x} -  \frac{t_\alpha sd }{ \sqrt{n} }; \bar{x} +  \frac{t_\alpha sd }{ \sqrt{n} }]
           }
         }
-        
+
         \item{\bold{ Median of probabilities (\code{prob.median})}}{
-        
-          This ensemble-model corresponds to the median probability over the selected models. The median is less sensitive to outliers than the mean. In practical terms, calculating the median requires more time and memory than the mean (or even weighting mean) as it asks to load all predictions to then extract the median. It may need to be considered in case of large dataset. 
+
+          This ensemble-model corresponds to the median probability over the selected models. The median is less sensitive to outliers than the mean. In practical terms, calculating the median requires more time and memory than the mean (or even weighting mean) as it asks to load all predictions to then extract the median. It may need to be considered in case of large dataset.
         }
-        
+
         \item{\bold{ Models committee averaging (\code{committee.averaging})}}{
-        
-          To do this model, the probabilities from the selected models are first transformed into binary data according to the thresholds defined at \code{\link[biomod2]{BIOMOD_Modeling}} step (maximizing evaluation metric score over \sQuote{testing dataset} ). The committee averaging score is then the average of binary predictions. It is built on the analogy of a simple vote. Each model vote for the species being ether present or absent. For each site, the sum of 1 is then divided by the number of models. The interesting feature of this measure is that it gives both a prediction and a measure of uncertainty. When the prediction is close to 0 or 1, it means that all models agree to predict 0 and 1 respectively. When the prediction is around 0.5, it means that half the models predict 1 and the other half 0.  
+
+          To do this model, the probabilities from the selected models are first transformed into binary data according to the thresholds defined at \code{\link[biomod2]{BIOMOD_Modeling}} step (maximizing evaluation metric score over \sQuote{testing dataset} ). The committee averaging score is then the average of binary predictions. It is built on the analogy of a simple vote. Each model vote for the species being ether present or absent. For each site, the sum of 1 is then divided by the number of models. The interesting feature of this measure is that it gives both a prediction and a measure of uncertainty. When the prediction is close to 0 or 1, it means that all models agree to predict 0 and 1 respectively. When the prediction is around 0.5, it means that half the models predict 1 and the other half 0.
         }
-        
+
         \item{\bold{ Weighted mean of probabilities (\code{prob.mean.weight} & \code{prob.mean.weight.decay})}}{
-        
-          This algorithm return the mean weighted (or more precisely this is the weighted sum) by the selected evaluation method scores (better a model is, more importance it has in the ensemble). The scores come from \code{\link[biomod2]{BIOMOD_Modeling}} step. 
-          
+
+          This algorithm return the mean weighted (or more precisely this is the weighted sum) by the selected evaluation method scores (better a model is, more importance it has in the ensemble). The scores come from \code{\link[biomod2]{BIOMOD_Modeling}} step.
+
           The \code{prob.mean.weight.decay} is the ratio between a weight and the following or prior one. The formula is : W = W(-1) * \code{prob.mean.weight.decay}. For example, with the value of 1.6 and 4 weights wanted, the relative importance of the weights will be 1 /1.6/2.56(=1.6*1.6)/4.096(=2.56*1.6) from the weakest to the strongest, and gives 0.11/0.17/0.275/0.445 considering that the sum of the weights is equal to one. The lower the \code{prob.mean.weight.decay}, the smoother the differences between the weights enhancing a weak discrimination between models.
-          
+
           The value 'proportional' (default) is also possible for the \code{prob.mean.weight.decay}: the weights are awarded for each method proportionally to their evaluation scores. The advantage is that the discrimination is more fair than with the \code{prob.mean.weight.decay}. In the latter case, close scores can strongly diverge in the weights they are awarded, when the proportional method will consider them as being fairly similar in prediction quality and award them a similar weight.
-          It is also possible to define a function as \code{prob.mean.weight.decay} argument. In this case the given function will be applied to models scores to transforme them into weights that will be used for wheigted mean ensemble model building. For instance if you specified \code{ function(x){x^2} } as \code{prob.mean.weight.decay}, the squared of evaluation score of each model will be used to weight formal models predictions. 
+          It is also possible to define a function as \code{prob.mean.weight.decay} argument. In this case the given function will be applied to models scores to transforme them into weights that will be used for wheigted mean ensemble model building. For instance if you specified \code{ function(x){x^2} } as \code{prob.mean.weight.decay}, the squared of evaluation score of each model will be used to weight formal models predictions.
         }
-        
+
       }
     }
-    
+
   } % end of itemize
-  
-} % end of detail 
+
+} % end of detail
 
 \value{
 A \code{"\link[=BIOMOD.EnsembleModeling.out-class]{BIOMOD.EnsembleModeling.out}"}. This object will be later given to \code{\link[biomod2]{BIOMOD_EnsembleForecasting}} if you want to make some projections of this ensemble-models.
@@ -153,7 +153,7 @@ Models are now combined by repetition, other way to combine them (e.g. by Models
 }
 
 
-\author{ 
+\author{
 Damien Georges & Wilfried Thuiller with participation of Robin Engler
 }
 
@@ -170,7 +170,7 @@ head(DataSpecies)
 # the name of studied species
 myRespName <- 'GuloGulo'
 
-# the presence/absences data for our species 
+# the presence/absences data for our species
 myResp <- as.numeric(DataSpecies[,myRespName])
 
 # the XY coordinates of species data
@@ -178,15 +178,15 @@ myRespXY <- DataSpecies[,c("X_WGS84","Y_WGS84")]
 
 
 # Environmental variables extracted from BIOCLIM (bio_3, bio_4, bio_7, bio_11 & bio_12)
-myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd", 
+myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd",
                      package="biomod2"),
-                system.file( "external/bioclim/current/bio4.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio7.grd", 
-                             package="biomod2"),  
-                system.file( "external/bioclim/current/bio11.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio12.grd", 
+                system.file( "external/bioclim/current/bio4.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio7.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio11.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio12.grd",
                              package="biomod2"))
 
 # 1. Formatting Data
@@ -194,24 +194,24 @@ myBiomodData <- BIOMOD_FormatingData(resp.var = myResp,
                                      expl.var = myExpl,
                                      resp.xy = myRespXY,
                                      resp.name = myRespName)
-       
+
 # 2. Defining Models Options using default options.
 myBiomodOption <- BIOMOD_ModelingOptions()
 
 # 3. Doing Modelisation
 
-myBiomodModelOut <- BIOMOD_Modeling( myBiomodData, 
-                                       models = c('SRE','CTA','RF'), 
-                                       models.options = myBiomodOption, 
-                                       NbRunEval=1, 
-                                       DataSplit=80, 
-                                       Yweights=NULL, 
-                                       VarImport=3, 
+myBiomodModelOut <- BIOMOD_Modeling( myBiomodData,
+                                       models = c('SRE','CTA','RF'),
+                                       models.options = myBiomodOption,
+                                       NbRunEval=1,
+                                       DataSplit=80,
+                                       Yweights=NULL,
+                                       VarImport=3,
                                        models.eval.meth = c('TSS'),
                                        SaveObj = TRUE,
                                        rescal.all.models = FALSE,
                                        do.full.models = FALSE)
-                                       
+
 # 4. Doing Ensemble Modelling
 myBiomodEM <- BIOMOD_EnsembleModeling( modeling.output = myBiomodModelOut,
                            chosen.models = 'all',
@@ -226,15 +226,15 @@ myBiomodEM <- BIOMOD_EnsembleModeling( modeling.output = myBiomodModelOut,
                            prob.median = FALSE,
                            committee.averaging = FALSE,
                            prob.mean.weight = TRUE,
-                           prob.mean.weight.decay = 'proportional' )   
-                                       
+                           prob.mean.weight.decay = 'proportional' )
+
 # print summary
 myBiomodEM
 
 # get evaluation scores
 get_evaluations(myBiomodEM)
 
-                                    
+
 }
 
 \keyword{ models }

--- a/man/BIOMOD_FormatingData.Rd
+++ b/man/BIOMOD_FormatingData.Rd
@@ -7,7 +7,7 @@
 
 \description{
 This function rearranges the user's input data to make sure they can be used within \pkg{biomod2}.
-The function allows to select pseudo-absences or background data in the case that true absences data are not available, or to add pseudo-asbence data to an existing set of absence  (see details).
+The function allows to select pseudo-absences or background data in the case that true absences data are not available, or to add pseudo-absence data to an existing set of absence  (see details).
 }
 \usage{
 BIOMOD_FormatingData(resp.var,
@@ -28,118 +28,118 @@ BIOMOD_FormatingData(resp.var,
 }
 
 \arguments{
-	
+
   \item{resp.var}{ a vector, \code{\link[sp]{SpatialPointsDataFrame}} (or \code{\link[sp]{SpatialPoints}} if you work with \sQuote{only presences} data) containing species data (a single species) in binary format (ones for presences, zeros for true absences and NA for indeterminated ) that will be \bold{used to build the species distribution models}. }
-  
+
   \item{expl.var}{ a \code{matrix}, \code{data.frame}, \code{\link[sp]{SpatialPointsDataFrame}} or \code{\link[raster:stack]{RasterStack}} containing your explanatory variables that will be \bold{used to build your models}.}
-  
+
   \item{resp.xy}{ optional 2 columns \code{matrix} containing the X and Y coordinates of resp.var (only consider if resp.var is a vector) that will be \bold{used to build your models}.}
-  
+
   \item{eval.resp.var}{ a vector, \code{\link[sp]{SpatialPointsDataFrame}} your species data (a single species) in binary format (ones for presences, zeros for true absences and NA for indeterminated ) that will be \bold{used to evaluate the models with independant data (or past data for instance)}.}
-  
+
   \item{eval.expl.var}{a \code{matrix}, \code{data.frame}, \code{\link[sp]{SpatialPointsDataFrame}} or \code{\link[raster:stack]{RasterStack}} containing your explanatory variables that will be \bold{used to evaluate the models with independant data (or past data for instance)}.}
-  
+
   \item{eval.resp.xy}{opional 2 columns \code{matrix} containing the X and Y coordinates of resp.var (only consider if resp.var is a vector) that will be \bold{used to evaluate the modelswith independant data (or past data for instance)}.}
-  
+
   \item{resp.name}{ response variable name (character). The species name. }
-  
+
   \item{PA.nb.rep}{ number of required Pseudo Absences selection (if needed). 0 by Default.}
-  
+
   \item{PA.nb.absences}{ number of pseudo-absence selected for each repetition (when PA.nb.rep > 0) of the selection (true absences included)}
-  
+
   \item{PA.strategy}{ strategy for selecting the Pseudo Absences (must be \sQuote{random}, \sQuote{sre}, \sQuote{disk} or \sQuote{user.defined})}
-  
+
   \item{PA.dist.min}{minimal distance to presences for \sQuote{disk} Pseudo Absences selection (in meters if the explanatory is a not projected raster (+proj=longlat) and in map units (typically also meters) when it is projected or when explanatory variables are stored within table )}
-  
+
   \item{PA.dist.max}{maximal distance to presences for \sQuote{disk} Pseudo Absences selection(in meters if the explanatory is a not projected raster (+proj=longlat) and in map units (typically also meters) when it is projected or when explanatory variables are stored within table ) }
-  
+
   \item{PA.sre.quant}{quantile used for \sQuote{sre} Pseudo Absences selection}
-  
-  \item{PA.table}{a \code{matrix} (or a \code{data.frame}) having as many rows than \code{resp.var} values. Each column  correspund to a Pseudo-absences selection. It contains \code{TRUE} or \code{FALSE} indicating which values of \code{resp.var} will be considered to build models. It must be used with \sQuote{user.defined} \code{PA.strategy}.}
-  
-  \item{na.rm}{locical, if TRUE, all points having one or several missing value for environmental data will be removed from analyse }
+
+  \item{PA.table}{a \code{matrix} (or a \code{data.frame}) having as many rows than \code{resp.var} values. Each column corresponds to a Pseudo-absences selection. It contains \code{TRUE} or \code{FALSE} indicating which values of \code{resp.var} will be considered to build models. It must be used with \sQuote{user.defined} \code{PA.strategy}.}
+
+  \item{na.rm}{logical, if TRUE, all points having one or several missing value for environmental data will be removed from the analysis}
 }
 
 \details{
-  This function homogenises the initial data for making sure the modelling exercie will be completed with all the required data. It supports different kind of inputs. 
-  
-  IMPORTANT: When the explanatory data are given in \code{rasterLayer} or \code{rasterStack} objects, \pkg{biomod2} will be extract the variables onto the XY coordinates of the presence (and absence is any) vector. Be sure to give the XY coordinates (\sQuote{resp.xy}) in the same projection system than the raster objects. Same for the evaluation data in the case some sort of independant (or past) data are available (\sQuote{eval.resp.xy}). 
+  This function homogeneises the initial data for making sure the modelling exercie will be completed with all the required data. It supports different kind of inputs.
+
+  IMPORTANT: When the explanatory data are given in \code{rasterLayer} or \code{rasterStack} objects, \pkg{biomod2} will be extract the variables onto the XY coordinates of the presence (and absence is any) vector. Be sure to give the XY coordinates (\sQuote{resp.xy}) in the same projection system than the raster objects. Same for the evaluation data in the case some sort of independant (or past) data are available (\sQuote{eval.resp.xy}).
   When the explanatory variables are given in \code{\link[sp]{SpatialPointsDataFrame}}, the same requirements are asked than for the raster objects. The XY coordinates must be given to make sure biomod2 can extract the explanatory variables onto the presence (absence) data
-  When the explanatory variables are stored in a data.frame, make sure there are in the same order than the response variable. \pkg{biomod2} will simply merge the datasets without considering the XY coordinates. 
-  
-  When both presence and absence data are available, and there is enough absences: set sQuote{PA.nb.rep} to 0. No pseudo-absence will be extracted. 
-  
-  When no true absences are given or when there are not numerous enough. It's advise to make several pseudo absences selections. That way the influence of the pseudo-absence selection could then be estimated later on. If the user do not want to run several repetition, make sure to select a relatively high number pseudo-absence. Make sure the number of pseudo-absence data is not higher than the maximum number of potential pseudo-absence (e.g. do not select 10,000 pseudo-absence when the rasterStack or data.frame do not contain more than 2000 pixels or rows). 
+  When the explanatory variables are stored in a data.frame, make sure there are in the same order than the response variable. \pkg{biomod2} will simply merge the datasets without considering the XY coordinates.
+
+  When both presence and absence data are available, and there is enough absences: set sQuote{PA.nb.rep} to 0. No pseudo-absence will be extracted.
+
+  When no true absences are given or when there are not numerous enough. It's advise to make several pseudo absences selections. That way the influence of the pseudo-absence selection could then be estimated later on. If the user do not want to run several repetition, make sure to select a relatively high number pseudo-absence. Make sure the number of pseudo-absence data is not higher than the maximum number of potential pseudo-absence (e.g. do not select 10,000 pseudo-absence when the rasterStack or data.frame do not contain more than 2000 pixels or rows).
 
   \enumerate{
     \item{\bold{Response variable encoding}}{
-    
+
       \code{BIOMOD_FormatingData} concerns a single species at a time so \code{resp.var} must be a uni-dimentional object.
-    
+
       Response variable must be a \code{vector} or  a one column \code{data.frame}/\code{matrix}/\code{\link[sp]{SpatialPointsDataFrame}} ( \code{\link[sp]{SpatialPoints}} are also allowed if you work with \sQuote{only presences} data) object.
       As most of \pkg{biomod2} models need Presences AND Absences data, the response variable must contain some absences (if there are not, make sure to select pseudo-absence). In the input \code{resp.var} argument, the data should be coded in the following way :
       \itemize{
         \item{Presences : 1}
-        \item{True Absesnces : 0 (if any)}
+        \item{True Absences : 0 (if any)}
         \item{No Information : NA (if any, might latter be used for pseudo-absence)}
       }
-      
-      If \code{resp.var} is a non-spatial object (\code{vector}, \code{matrix}/\code{data.frame}) and that some models requiring spatial data are being used (e.g. MAXENT.Phillips) and/or pseudo absences spatialy dependent (i.e 'disk'), make sure to give the XY coordinates of the sites/rows (\sQuote{resp.xy}). 
-      
+
+      If \code{resp.var} is a non-spatial object (\code{vector}, \code{matrix}/\code{data.frame}) and that some models requiring spatial data are being used (e.g. MAXENT.Phillips) and/or pseudo absences spatialy dependent (i.e 'disk'), make sure to give the XY coordinates of the sites/rows (\sQuote{resp.xy}).
+
     }
-    
+
     \item{\bold{Explanatory variables encoding}}{
-    
+
       Explanatory variables must be stored together in a multidimentional object. It may be a \code{matrix},  a \code{data.frame}, a \code{\link[sp]{SpatialPointsDataFrame}} or a \code{rasterStack} object. Factorial variables are allowed here even if that can lead to some models omissions.
     }
-    
+
     \item{\bold{Evaluation Data}}{
-    
-      If you have data enough, we strongly recommand to split your dataset into 2 part : one for training/calibrating and testing the models and another to evaluate it. If you do it, fill the \code{eval.resp.var}, \code{eval.expl.var} and optionally the \code{eval.resp.xy} arguments whith this data. The advantage of working with a specific dataset for evaluating your models is that you will be able to evaluate more properly your \sQuote{ensemble modeled} models. That being said, this argument is optional and you may prefer only to test (kind of evaluation) your models only with a \sQuote{cross-validation} procedure (see Models function). The best practice is to use one set of data for training/calibrating, one set of testing and one for evaluating. The calibration and testing of the data can be done automaticaly in \pkg{biomod2} in the Models function. The dataset for evaluation must be entered in \code{BIOMOD_FormatingData}. 
-    
+
+      If you have data enough, we strongly recommand to split your dataset into 2 part : one for training/calibrating and testing the models and another to evaluate it. If you do it, fill the \code{eval.resp.var}, \code{eval.expl.var} and optionally the \code{eval.resp.xy} arguments whith this data. The advantage of working with a specific dataset for evaluating your models is that you will be able to evaluate more properly your \sQuote{ensemble modeled} models. That being said, this argument is optional and you may prefer only to test (kind of evaluation) your models only with a \sQuote{cross-validation} procedure (see Models function). The best practice is to use one set of data for training/calibrating, one set of testing and one for evaluating. The calibration and testing of the data can be done automatically in \pkg{biomod2} in the Models function. The dataset for evaluation must be entered in \code{BIOMOD_FormatingData}.
+
     }
-    
+
     \item{\bold{Pseudo Absences selection}}{
-    
+
       The \code{PA.xxx}'s arguments let you parametrise your pseudo absences selection if you want some. It's an optional step.
-      
+
       Pseudo absences will be selected within the \sQuote{background data} and might be constrained by a defined \sQuote{strategy}.
-      
+
       \enumerate{
         \item{background data}{
-        
-        \sQuote{Background data} represents data there is no information whether the species of interest occurs or not. It is defined by the \sQuote{No Information} data of your \code{resp.var} if you give some. If not, (i.e Only presences data or all cells with a define presence or absence state) the backgroud will be take into your \code{expl.var} object if it's a \code{RasterStack}.
-        
+
+        \sQuote{Background data} represents data there is no information whether the species of interest occurs or not. It is defined by the \sQuote{No Information} data of your \code{resp.var} if you give some. If not, (i.e Only presences data or all cells with a define presence or absence state) the background will be take into your \code{expl.var} object if it's a \code{RasterStack}.
+
         }
-  
+
         \item{strategy}{
-        
+
           The strategy allows to constrain the choice of pseudo-absence within the \sQuote{background data}.
           3 ways are currently implemented to select the pseudo-absences candidate cells (\code{PA.strategy} argument):
           \itemize{
             \item{\sQuote{random}: all cell of initial background are Pseudo absences candidates. The choice is made randomly given the number of pseudo-absence to select \code{PA.nb.absences}.}
-            
+
             \item{\sQuote{disk}: you may define a minimal (\code{PA.dist.min}), respectively a maximal (\code{PA.dist.max}) distance to presences points for selecting your pseudo absences candidates. That may be usefull if you don't want to select pseudo-absences too close to your presences (same niche and to avoid pseudo-replication), respectively too far from your presences (localised sampling startegy). }
-            
+
             \item{\sQuote{sre}: Pseudo absences candidates have to be selected in condition that differs from a defined proportion (\code{PA.sre.quant}) of presences data. It forces pseudo absences to be selected outside of the broadly defined environemental conditions for the species. It means that a surface range envelop model (sre, similar the BIOCLIM) is first carried out (using the specified quantile) on the species of interest, and then the pseudo-absence data are extracted outside of this envelop. This particular case may lead to over optimistic models evaluations.}
-            
+
             \item{\sQuote{user.defined}: In this case, pseudo absences selection should have been done in a previous step. This pseudo absences have to be reference into a well formated \code{data.frame} (e.g. \code{PA.table} argument)}
-          }          
-            
+          }
+
         }
 
       }
-      
-      
+
+
 
     }
   } % end enumerate
-  
+
 } %end detail section
 
 \value{
   A \code{'data.formated.Biomod.object'} for \code{\link[biomod2]{BIOMOD_Modeling}}.
-  It is strongly advised to check whether this formated data corresponds to what was expected. A summary is easily printed by simply tipping the name of the object. A generic plot function is also available to display the different dataset in the geographic space.  
+  It is strongly advised to check whether this formated data corresponds to what was expected. A summary is easily printed by simply tipping the name of the object. A generic plot function is also available to display the different dataset in the geographic space.
 }
 
 \author{ Wilfried Thuiller, Damien Georges }
@@ -155,7 +155,7 @@ head(DataSpecies)
 # the name of studied species
 myRespName <- 'GuloGulo'
 
-# the presence/absences data for our species 
+# the presence/absences data for our species
 myResp <- as.numeric(DataSpecies[,myRespName])
 
 # the XY coordinates of species data
@@ -163,26 +163,26 @@ myRespXY <- DataSpecies[,c("X_WGS84","Y_WGS84")]
 
 
 # Environmental variables extracted from BIOCLIM (bio_3, bio_4, bio_7, bio_11 & bio_12)
-myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd", 
+myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd",
                      package="biomod2"),
-                system.file( "external/bioclim/current/bio4.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio7.grd", 
-                             package="biomod2"),  
-                system.file( "external/bioclim/current/bio11.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio12.grd", 
+                system.file( "external/bioclim/current/bio4.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio7.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio11.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio12.grd",
                              package="biomod2"))
 # 1. Formatting Data
 myBiomodData <- BIOMOD_FormatingData(resp.var = myResp,
                                      expl.var = myExpl,
                                      resp.xy = myRespXY,
                                      resp.name = myRespName)
-                                     
+
 myBiomodData
 plot(myBiomodData)
 
 }
-                 
+
 \keyword{ models }
 \keyword{ datasets }

--- a/man/BIOMOD_FormatingData.Rd
+++ b/man/BIOMOD_FormatingData.Rd
@@ -3,7 +3,7 @@
 \name{BIOMOD_FormatingData}
 \alias{BIOMOD_FormatingData}
 
-\title{ Initialise the datasets for usage in \pkg{biomod2} }
+\title{ Initialize the datasets for usage in \pkg{biomod2} }
 
 \description{
 This function rearranges the user's input data to make sure they can be used within \pkg{biomod2}.
@@ -29,17 +29,17 @@ BIOMOD_FormatingData(resp.var,
 
 \arguments{
 
-  \item{resp.var}{ a vector, \code{\link[sp]{SpatialPointsDataFrame}} (or \code{\link[sp]{SpatialPoints}} if you work with \sQuote{only presences} data) containing species data (a single species) in binary format (ones for presences, zeros for true absences and NA for indeterminated ) that will be \bold{used to build the species distribution models}. }
+  \item{resp.var}{ a vector, \code{\link[sp]{SpatialPointsDataFrame}} (or \code{\link[sp]{SpatialPoints}} if you work with \sQuote{only presences} data) containing species data (a single species) in binary format (ones for presences, zeros for true absences and NA for indeterminate ) that will be \bold{used to build the species distribution models}. }
 
   \item{expl.var}{ a \code{matrix}, \code{data.frame}, \code{\link[sp]{SpatialPointsDataFrame}} or \code{\link[raster:stack]{RasterStack}} containing your explanatory variables that will be \bold{used to build your models}.}
 
   \item{resp.xy}{ optional 2 columns \code{matrix} containing the X and Y coordinates of resp.var (only consider if resp.var is a vector) that will be \bold{used to build your models}.}
 
-  \item{eval.resp.var}{ a vector, \code{\link[sp]{SpatialPointsDataFrame}} your species data (a single species) in binary format (ones for presences, zeros for true absences and NA for indeterminated ) that will be \bold{used to evaluate the models with independant data (or past data for instance)}.}
+  \item{eval.resp.var}{ a vector, \code{\link[sp]{SpatialPointsDataFrame}} your species data (a single species) in binary format (ones for presences, zeros for true absences and NA for indeterminate ) that will be \bold{used to evaluate the models with independent data (or past data for instance)}.}
 
-  \item{eval.expl.var}{a \code{matrix}, \code{data.frame}, \code{\link[sp]{SpatialPointsDataFrame}} or \code{\link[raster:stack]{RasterStack}} containing your explanatory variables that will be \bold{used to evaluate the models with independant data (or past data for instance)}.}
+  \item{eval.expl.var}{a \code{matrix}, \code{data.frame}, \code{\link[sp]{SpatialPointsDataFrame}} or \code{\link[raster:stack]{RasterStack}} containing your explanatory variables that will be \bold{used to evaluate the models with independent data (or past data for instance)}.}
 
-  \item{eval.resp.xy}{opional 2 columns \code{matrix} containing the X and Y coordinates of resp.var (only consider if resp.var is a vector) that will be \bold{used to evaluate the modelswith independant data (or past data for instance)}.}
+  \item{eval.resp.xy}{optional 2 columns \code{matrix} containing the X and Y coordinates of resp.var (only consider if resp.var is a vector) that will be \bold{used to evaluate the modelswith independent data (or past data for instance)}.}
 
   \item{resp.name}{ response variable name (character). The species name. }
 
@@ -61,9 +61,9 @@ BIOMOD_FormatingData(resp.var,
 }
 
 \details{
-  This function homogeneises the initial data for making sure the modelling exercie will be completed with all the required data. It supports different kind of inputs.
+  This function homogenizes the initial data for making sure the modelling exercise will be completed with all the required data. It supports different kind of inputs.
 
-  IMPORTANT: When the explanatory data are given in \code{rasterLayer} or \code{rasterStack} objects, \pkg{biomod2} will be extract the variables onto the XY coordinates of the presence (and absence is any) vector. Be sure to give the XY coordinates (\sQuote{resp.xy}) in the same projection system than the raster objects. Same for the evaluation data in the case some sort of independant (or past) data are available (\sQuote{eval.resp.xy}).
+  IMPORTANT: When the explanatory data are given in \code{rasterLayer} or \code{rasterStack} objects, \pkg{biomod2} will be extract the variables onto the XY coordinates of the presence (and absence is any) vector. Be sure to give the XY coordinates (\sQuote{resp.xy}) in the same projection system than the raster objects. Same for the evaluation data in the case some sort of independent (or past) data are available (\sQuote{eval.resp.xy}).
   When the explanatory variables are given in \code{\link[sp]{SpatialPointsDataFrame}}, the same requirements are asked than for the raster objects. The XY coordinates must be given to make sure biomod2 can extract the explanatory variables onto the presence (absence) data
   When the explanatory variables are stored in a data.frame, make sure there are in the same order than the response variable. \pkg{biomod2} will simply merge the datasets without considering the XY coordinates.
 
@@ -74,7 +74,7 @@ BIOMOD_FormatingData(resp.var,
   \enumerate{
     \item{\bold{Response variable encoding}}{
 
-      \code{BIOMOD_FormatingData} concerns a single species at a time so \code{resp.var} must be a uni-dimentional object.
+      \code{BIOMOD_FormatingData} concerns a single species at a time so \code{resp.var} must be a uni-dimensional object.
 
       Response variable must be a \code{vector} or  a one column \code{data.frame}/\code{matrix}/\code{\link[sp]{SpatialPointsDataFrame}} ( \code{\link[sp]{SpatialPoints}} are also allowed if you work with \sQuote{only presences} data) object.
       As most of \pkg{biomod2} models need Presences AND Absences data, the response variable must contain some absences (if there are not, make sure to select pseudo-absence). In the input \code{resp.var} argument, the data should be coded in the following way :
@@ -84,24 +84,24 @@ BIOMOD_FormatingData(resp.var,
         \item{No Information : NA (if any, might latter be used for pseudo-absence)}
       }
 
-      If \code{resp.var} is a non-spatial object (\code{vector}, \code{matrix}/\code{data.frame}) and that some models requiring spatial data are being used (e.g. MAXENT.Phillips) and/or pseudo absences spatialy dependent (i.e 'disk'), make sure to give the XY coordinates of the sites/rows (\sQuote{resp.xy}).
+      If \code{resp.var} is a non-spatial object (\code{vector}, \code{matrix}/\code{data.frame}) and that some models requiring spatial data are being used (e.g. MAXENT.Phillips) and/or pseudo absences spatially dependent (i.e 'disk'), make sure to give the XY coordinates of the sites/rows (\sQuote{resp.xy}).
 
     }
 
     \item{\bold{Explanatory variables encoding}}{
 
-      Explanatory variables must be stored together in a multidimentional object. It may be a \code{matrix},  a \code{data.frame}, a \code{\link[sp]{SpatialPointsDataFrame}} or a \code{rasterStack} object. Factorial variables are allowed here even if that can lead to some models omissions.
+      Explanatory variables must be stored together in a multi-dimensional object. It may be a \code{matrix},  a \code{data.frame}, a \code{\link[sp]{SpatialPointsDataFrame}} or a \code{rasterStack} object. Factorial variables are allowed here even if that can lead to some models omissions.
     }
 
     \item{\bold{Evaluation Data}}{
 
-      If you have data enough, we strongly recommand to split your dataset into 2 part : one for training/calibrating and testing the models and another to evaluate it. If you do it, fill the \code{eval.resp.var}, \code{eval.expl.var} and optionally the \code{eval.resp.xy} arguments whith this data. The advantage of working with a specific dataset for evaluating your models is that you will be able to evaluate more properly your \sQuote{ensemble modeled} models. That being said, this argument is optional and you may prefer only to test (kind of evaluation) your models only with a \sQuote{cross-validation} procedure (see Models function). The best practice is to use one set of data for training/calibrating, one set of testing and one for evaluating. The calibration and testing of the data can be done automatically in \pkg{biomod2} in the Models function. The dataset for evaluation must be entered in \code{BIOMOD_FormatingData}.
+      If you have data enough, we strongly recommend to split your dataset into 2 part : one for training/calibrating and testing the models and another to evaluate it. If you do it, fill the \code{eval.resp.var}, \code{eval.expl.var} and optionally the \code{eval.resp.xy} arguments with this data. The advantage of working with a specific dataset for evaluating your models is that you will be able to evaluate more properly your \sQuote{ensemble modeled} models. That being said, this argument is optional and you may prefer only to test (kind of evaluation) your models only with a \sQuote{cross-validation} procedure (see Models function). The best practice is to use one set of data for training/calibrating, one set of testing and one for evaluating. The calibration and testing of the data can be done automatically in \pkg{biomod2} in the Models function. The dataset for evaluation must be entered in \code{BIOMOD_FormatingData}.
 
     }
 
     \item{\bold{Pseudo Absences selection}}{
 
-      The \code{PA.xxx}'s arguments let you parametrise your pseudo absences selection if you want some. It's an optional step.
+      The \code{PA.xxx}'s arguments let you parameterize your pseudo absences selection if you want some. It's an optional step.
 
       Pseudo absences will be selected within the \sQuote{background data} and might be constrained by a defined \sQuote{strategy}.
 
@@ -119,11 +119,11 @@ BIOMOD_FormatingData(resp.var,
           \itemize{
             \item{\sQuote{random}: all cell of initial background are Pseudo absences candidates. The choice is made randomly given the number of pseudo-absence to select \code{PA.nb.absences}.}
 
-            \item{\sQuote{disk}: you may define a minimal (\code{PA.dist.min}), respectively a maximal (\code{PA.dist.max}) distance to presences points for selecting your pseudo absences candidates. That may be usefull if you don't want to select pseudo-absences too close to your presences (same niche and to avoid pseudo-replication), respectively too far from your presences (localised sampling startegy). }
+            \item{\sQuote{disk}: you may define a minimal (\code{PA.dist.min}), respectively a maximal (\code{PA.dist.max}) distance to presences points for selecting your pseudo absences candidates. That may be useful if you don't want to select pseudo-absences too close to your presences (same niche and to avoid pseudo-replication), respectively too far from your presences (localized sampling strategy). }
 
-            \item{\sQuote{sre}: Pseudo absences candidates have to be selected in condition that differs from a defined proportion (\code{PA.sre.quant}) of presences data. It forces pseudo absences to be selected outside of the broadly defined environemental conditions for the species. It means that a surface range envelop model (sre, similar the BIOCLIM) is first carried out (using the specified quantile) on the species of interest, and then the pseudo-absence data are extracted outside of this envelop. This particular case may lead to over optimistic models evaluations.}
+            \item{\sQuote{sre}: Pseudo absences candidates have to be selected in condition that differs from a defined proportion (\code{PA.sre.quant}) of presences data. It forces pseudo absences to be selected outside of the broadly defined environmental conditions for the species. It means that a surface range envelop model (sre, similar the BIOCLIM) is first carried out (using the specified quantile) on the species of interest, and then the pseudo-absence data are extracted outside of this envelop. This particular case may lead to over optimistic models evaluations.}
 
-            \item{\sQuote{user.defined}: In this case, pseudo absences selection should have been done in a previous step. This pseudo absences have to be reference into a well formated \code{data.frame} (e.g. \code{PA.table} argument)}
+            \item{\sQuote{user.defined}: In this case, pseudo absences selection should have been done in a previous step. This pseudo absences have to be reference into a well formatted \code{data.frame} (e.g. \code{PA.table} argument)}
           }
 
         }
@@ -138,8 +138,8 @@ BIOMOD_FormatingData(resp.var,
 } %end detail section
 
 \value{
-  A \code{'data.formated.Biomod.object'} for \code{\link[biomod2]{BIOMOD_Modeling}}.
-  It is strongly advised to check whether this formated data corresponds to what was expected. A summary is easily printed by simply tipping the name of the object. A generic plot function is also available to display the different dataset in the geographic space.
+  A \code{'data.formatted.Biomod.object'} for \code{\link[biomod2]{BIOMOD_Modeling}}.
+  It is strongly advised to check whether this formatted data corresponds to what was expected. A summary is easily printed by simply tipping the name of the object. A generic plot function is also available to display the different dataset in the geographic space.
 }
 
 \author{ Wilfried Thuiller, Damien Georges }

--- a/man/BIOMOD_LoadModels.Rd
+++ b/man/BIOMOD_LoadModels.Rd
@@ -17,29 +17,29 @@
 
 \details{
   This function is particulary useful when you plane to make some response plot analyses. It will induce models, built at \code{\link[biomod2]{BIOMOD_Modeling}} step, loading in your working space.
-  
+
   If you run this function referencing only \code{bm.out} argument, all models built will be loaded. However, you can make a models subselection using the additional arguments (see below).
-  
+
   \bold{Additional arguments (\ldots{}) : }
   All the following arguments are optional.
-  
+
   \itemize{
 
     \item{\bold{models:}}{ a character vector defining the names of models (e.g c(\sQuote{GLM}, \sQuote{GAM}, \sQuote{RF}) ) you want to load (models subselection) }
     \item{\bold{run.eval:}}{ a character vector defining the names of evaluation run (e.g c(\sQuote{RUN1}, \sQuote{Full}) ) you want to load (repetition subselection) }
     \item{\bold{data.set:}}{ a character vector defining the names of data.set (e.g c(\sQuote{PA1}, \sQuote{PA2})) you want to load (pseudo absences subselection) }
     \item{\bold{path:}}{ the path to file where the species folder is. To be filled if species folder is different from your working directory) }
-    
+
   }
-  
+
 }
 
 \note{
-  \code{SRE} models are not supported yet. They will be automaticly excluded even if they are selected.
+  \code{SRE} models are not supported yet. They will be automatically excluded even if they are selected.
 }
 
 \value{
-  A character vector filled with the loaded models names. 
+  A character vector filled with the loaded models names.
 }
 
 
@@ -55,7 +55,7 @@ head(DataSpecies)
 # the name of studied species
 myRespName <- 'GuloGulo'
 
-# the presence/absences data for our species 
+# the presence/absences data for our species
 myResp <- as.numeric(DataSpecies[,myRespName])
 
 # the XY coordinates of species data
@@ -63,15 +63,15 @@ myRespXY <- DataSpecies[,c("X_WGS84","Y_WGS84")]
 
 
 # Environmental variables extracted from BIOCLIM (bio_3, bio_4, bio_7, bio_11 & bio_12)
-myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd", 
+myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd",
                      package="biomod2"),
-                system.file( "external/bioclim/current/bio4.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio7.grd", 
-                             package="biomod2"),  
-                system.file( "external/bioclim/current/bio11.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio12.grd", 
+                system.file( "external/bioclim/current/bio4.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio7.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio11.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio12.grd",
                              package="biomod2"))
 
 # 1. Formatting Data
@@ -80,21 +80,21 @@ myBiomodData <- BIOMOD_FormatingData(resp.var = myResp,
                                      resp.xy = myRespXY,
                                      resp.name = myRespName)
 
-                                                                     
+
 # 2. Defining Models Options using default options.
 myBiomodOption <- BIOMOD_ModelingOptions()
 
 # 3. Doing Modelisation
 
-myBiomodModelOut <- BIOMOD_Modeling( myBiomodData, 
-                                       models = c('RF'), 
-                                       models.options = myBiomodOption, 
-                                       NbRunEval=2, 
-                                       DataSplit=70, 
+myBiomodModelOut <- BIOMOD_Modeling( myBiomodData,
+                                       models = c('RF'),
+                                       models.options = myBiomodOption,
+                                       NbRunEval=2,
+                                       DataSplit=70,
                                        models.eval.meth = c('TSS'),
                                        SaveObj = TRUE,
                                        do.full.models = FALSE)
-                                       
+
 # 4. Loading some models built
 
 myLoadedModels <- BIOMOD_LoadModels(myBiomodModelOut, models='RF')
@@ -102,6 +102,6 @@ myLoadedModels <- BIOMOD_LoadModels(myBiomodModelOut, models='RF')
 myLoadedModels
 
 }
-                 
+
 \keyword{ models }
 \keyword{ datasets }

--- a/man/BIOMOD_LoadModels.Rd
+++ b/man/BIOMOD_LoadModels.Rd
@@ -16,7 +16,7 @@
 }
 
 \details{
-  This function is particulary useful when you plane to make some response plot analyses. It will induce models, built at \code{\link[biomod2]{BIOMOD_Modeling}} step, loading in your working space.
+  This function is particularly useful when you plane to make some response plot analyses. It will induce models, built at \code{\link[biomod2]{BIOMOD_Modeling}} step, loading in your working space.
 
   If you run this function referencing only \code{bm.out} argument, all models built will be loaded. However, you can make a models subselection using the additional arguments (see below).
 

--- a/man/BIOMOD_Modeling.Rd
+++ b/man/BIOMOD_Modeling.Rd
@@ -6,17 +6,17 @@
   This function allows to calibrate and evaluate a range of species distribution models techniques run over a given species. Calibrations are made on the whole sample or a random subpart. The predictive power of the different models is estimated using a range of evaluation metrics.
 }
 \usage{
-BIOMOD_Modeling( data, 
+BIOMOD_Modeling( data,
                  models = c('GLM','GBM','GAM','CTA','ANN',
-                            'SRE','FDA','MARS','RF','MAXENT.Phillips', 
-                            "MAXENT.Tsuruoka"), 
-                 models.options = NULL, 
-                 NbRunEval=1, 
-                 DataSplit=100, 
+                            'SRE','FDA','MARS','RF','MAXENT.Phillips',
+                            "MAXENT.Tsuruoka"),
+                 models.options = NULL,
+                 NbRunEval=1,
+                 DataSplit=100,
                  Yweights=NULL,
                  Prevalence=NULL,
-                 VarImport=0, 
-                 models.eval.meth = c('KAPPA','TSS','ROC'), 
+                 VarImport=0,
+                 models.eval.meth = c('KAPPA','TSS','ROC'),
                  SaveObj = TRUE,
                  rescal.all.models = FALSE,
                  do.full.models = TRUE,
@@ -26,9 +26,9 @@ BIOMOD_Modeling( data,
 
 \arguments{
   \item{data}{\code{BIOMOD.formated.data} object returned by \code{\link[biomod2]{BIOMOD_FormatingData}}}
-  \item{models}{vector of models names choosen among 'GLM', 'GBM', 'GAM', 'CTA', 'ANN', 'SRE', 'FDA', 'MARS', 'RF', 'MAXENT.Phillips' and "MAXENT.Tsuruoka" } 
+  \item{models}{vector of models names chosen among 'GLM', 'GBM', 'GAM', 'CTA', 'ANN', 'SRE', 'FDA', 'MARS', 'RF', 'MAXENT.Phillips' and "MAXENT.Tsuruoka" }
   \item{models.options}{\code{BIOMOD.models.options} object returned by \code{\link[biomod2]{BIOMOD_ModelingOptions}}}
-  \item{NbRunEval}{Number of Evaluation run} 
+  \item{NbRunEval}{Number of Evaluation run}
   \item{DataSplit}{\% of data used to calibrate the models, the remaining part will be used for testing }
   \item{Yweights}{response points weights}
   \item{Prevalence}{either \code{NULL} (default) or a 0-1 numeric used to build 'weighted response weights'}
@@ -40,7 +40,7 @@ BIOMOD_Modeling( data,
   \item{modeling.id}{character, the ID (=name) of modeling procedure. A random number by default. }
   \item{\ldots}{ further arguments :
     \itemize{
-      \item{\code{DataSplitTable} : a \code{matrix}, \code{data.frame} or a 3D \code{array} filled with \code{TRUE/FALSE} to specify which part of data must be used for models calibration (\code{TRUE}) and for models validation (\code{FALSE}). Each column correspund to a 'RUN'. If filled, args \code{NbRunEval}, \code{DataSplit} and \code{do.full.models} will be ignored.}
+      \item{\code{DataSplitTable} : a \code{matrix}, \code{data.frame} or a 3D \code{array} filled with \code{TRUE/FALSE} to specify which part of data must be used for models calibration (\code{TRUE}) and for models validation (\code{FALSE}). Each column corresponds to a 'RUN'. If filled, args \code{NbRunEval}, \code{DataSplit} and \code{do.full.models} will be ignored.}
     }}
 }
 
@@ -49,14 +49,14 @@ BIOMOD_Modeling( data,
 \enumerate{
 
   \item{\bold{data}}{
-  
-  If you have decide to add pseudo absences to your original dataset (see \code{\link[biomod2]{BIOMOD_FormatingData}}), NbPseudoAbsences * \code{NbRunEval + 1} models will be created. 
-  
+
+  If you have decide to add pseudo absences to your original dataset (see \code{\link[biomod2]{BIOMOD_FormatingData}}), NbPseudoAbsences * \code{NbRunEval + 1} models will be created.
+
   }
-  
+
   \item{\bold{models}}{
-  
-    The set of models to be calibrated on the data. 10 modeling techniques are currently available: 
+
+    The set of models to be calibrated on the data. 10 modeling techniques are currently available:
     \itemize{
       \item{GLM : Generalized Linear Model (\code{\link[stats]{glm}})}
       \item{GAM : Generalized Additive Model (\code{\link[gam]{gam}}, \code{\link[mgcv]{gam}} or \code{\link[mgcv]{bam}}, see \code{\link[biomod2]{BIOMOD_ModelingOptions} for details on algorithm selection})}
@@ -70,28 +70,28 @@ BIOMOD_Modeling( data,
       \item{MAXENT.Phillips: Maximum Entropy (\url{http://www.cs.princeton.edu/~schapire/maxent/})}
       \item{MAXENT.Tsuruoka: low-memory multinomial logistic regression (\code{\link[maxent]{maxent}})}
     }
-    
+
   }
-  
+
 
    \item{\bold{NbRunEval & DataSplit}}{
-   
-     As already explained in the \code{\link{BIOMOD_FormatingData}} help file, the common trend is to split the original dataset into two subsets, one to calibrate the models, and another one to evaluate them. Here we provide the possibility to repeat this process (calibration and evaluation) N times (\code{NbRunEval} times). The proportion of data kept for calibration is determined by the \code{DataSplit} argument (100\% - \code{DataSplit} will be used to evaluate the model). This sort of cross-validation allows to have a quite robust test of the models when independent data are not available. Each technique will also be calibrated on the complete original data. All the models produced by BIOMOD and their related informations are saved on the hard drive. 
-     
+
+     As already explained in the \code{\link{BIOMOD_FormatingData}} help file, the common trend is to split the original dataset into two subsets, one to calibrate the models, and another one to evaluate them. Here we provide the possibility to repeat this process (calibration and evaluation) N times (\code{NbRunEval} times). The proportion of data kept for calibration is determined by the \code{DataSplit} argument (100\% - \code{DataSplit} will be used to evaluate the model). This sort of cross-validation allows to have a quite robust test of the models when independent data are not available. Each technique will also be calibrated on the complete original data. All the models produced by BIOMOD and their related informations are saved on the hard drive.
+
    }
-  
+
   \item{\bold{Yweights & Prevalence}}{
-  
+
     Allows to give more or less weight to some particular observations. If these arguments is kept to NULL (\code{Yweights = NULL}, \code{Prevalence = NULL}), each observation (presence or absence) has the same weight (independent of the number of presences and absences). If \code{Prevalence = 0.5} absences will be weighted equally to the presences (i.e. the weighted sum of presence equals the weighted sum of absences). If prevalence is set below or above 0.5 absences or presences are given more weight, respectively.
-In the particular case that pseudo-absence data have been generated \code{BIOMOD_FormatingData} (\code{PA.nb.rep > 0}), weights are by default (\code{Prevalence = NULL}) calculated such that prevalence is 0.5, meaning that the presences will have the same importance as the absences in the calibration process of the models. Automatically created \code{Yweights} will be composed of integers to prevent different modelling issues. 
-Note that the \code{Prevalence} argument will always be ignored if \code{Yweights} are defined. 
-    
-    
+In the particular case that pseudo-absence data have been generated \code{BIOMOD_FormatingData} (\code{PA.nb.rep > 0}), weights are by default (\code{Prevalence = NULL}) calculated such that prevalence is 0.5, meaning that the presences will have the same importance as the absences in the calibration process of the models. Automatically created \code{Yweights} will be composed of integers to prevent different modelling issues.
+Note that the \code{Prevalence} argument will always be ignored if \code{Yweights} are defined.
+
+
   }
-  
+
   \item{\bold{models.eval.meth}}{
-  
-    The available evaluations methods are : 
+
+    The available evaluations methods are :
     \itemize{
       \item{\sQuote{ROC} : Relative Operating Characteristic}
       \item{\sQuote{KAPPA} : Cohen's Kappa (Heidke skill score) }
@@ -104,43 +104,43 @@ Note that the \code{Prevalence} argument will always be ignored if \code{Yweight
       \item{\sQuote{CSI} : Critical success index (threat score)}
       \item{\sQuote{ETS} : Equitable threat score (Gilbert skill score)}
     }
-    Some of them are scaled to have all an optimum at 1. You can choose one of more (vector) evaluation metric. By Default, only 'KAPPA', 'TSS' and 'ROC' evaluation are done. Please refer to the CAWRC website (\url{http://www.cawcr.gov.au/projects/verification/#Methods_for_dichotomous_forecasts}) to get detailled description of each metric.
-    
+    Some of them are scaled to have all an optimum at 1. You can choose one of more (vector) evaluation metric. By Default, only 'KAPPA', 'TSS' and 'ROC' evaluation are done. Please refer to the CAWRC website (\url{http://www.cawcr.gov.au/projects/verification/#Methods_for_dichotomous_forecasts}) to get detailed description of each metric.
+
   }
-  
+
   \item{\bold{SaveObj}}{
-  
+
   If this argument is set to False, it may prevent the evaluation of the \sQuote{ensemble modelled} models in further steps. We strongly recommend to always keep this argument \code{TRUE} even it asks for free space onto the hard drive.
   }
-  
+
   \item{\bold{rescal.all.models}}{
-  
-  \bold{This parameter is quite experimental and we adcise not to use it. It should lead to reduction in projection scale amplitude }
-  Some categorical models have to be scaled in every case (\sQuote{FDA}, \sQuote{ANN}). But It may be interesting to scale all model computed to ensure that they will produced comparable predictions (0-1000 ladder). That's particularly useful when you do some ensemble forecasting to remove the scale prediction effect (the more extended projections are, the more they influence ensemble forecasting results). 
+
+  \bold{This parameter is quite experimental and we advise not to use it. It should lead to reduction in projection scale amplitude }
+  Some categorical models have to be scaled in every case (\sQuote{FDA}, \sQuote{ANN}). But It may be interesting to scale all model computed to ensure that they will produced comparable predictions (0-1000 ladder). That's particularly useful when you do some ensemble forecasting to remove the scale prediction effect (the more extended projections are, the more they influence ensemble forecasting results).
   }
 
   \item{\bold{do.full.models}}{
-  
-  Building models with all information available may be usefull in some particular cases (i.e. rare species with few presences points). The main drawback of this method is that, if you don't give separated data for models evaluation, your models will be evaluated with the same data that the ones used for calibration. Thats will lead to over-optimistic evaluation scores. Be carefull whith this '_Full' models interpretation.
+
+  Building models with all information available may be usefull in some particular cases (i.e. rare species with few presences points). The main drawback of this method is that, if you don't give separated data for models evaluation, your models will be evaluated with the same data that the ones used for calibration. Thats will lead to over-optimistic evaluation scores. Be careful whith this '_Full' models interpretation.
   }
 } % end of enumerate
-} % end of detail 
+} % end of detail
 
 \value{
   A BIOMOD.models.out object
-    
+
   See \code{"\link[=BIOMOD.models.out-class]{BIOMOD.models.out}"} for details.
-  
+
   Additional objects are stored out of R in two different directories for memory storage purposes. They are created by the function directly on the root
   of your working directory set in R ("models" directory). This one contains each calibrated model for each repetition and pseudo-absence run. A hidden folder \file{.DATA_BIOMOD} contains some files (predictions, original dataset copy, pseudo absences chosen...) used by other functions like \code{\link[biomod2]{BIOMOD_Projection}} or \code{\link[biomod2]{BIOMOD_EnsembleModeling}} .
-  
-  The models are currently stored as objects to be read exclusively in R. To load them back (the same stands for all objects stored on the hard disk) 
-  use the \code{\link{load}} function (see examples section below). 
-   
+
+  The models are currently stored as objects to be read exclusively in R. To load them back (the same stands for all objects stored on the hard disk)
+  use the \code{\link{load}} function (see examples section below).
+
 }
 
 
-\author{ 
+\author{
 Wilfried Thuiller, Damien Georges, Robin Engler
 }
 
@@ -157,7 +157,7 @@ head(DataSpecies)
 # the name of studied species
 myRespName <- 'GuloGulo'
 
-# the presence/absences data for our species 
+# the presence/absences data for our species
 myResp <- as.numeric(DataSpecies[,myRespName])
 
 # the XY coordinates of species data
@@ -165,15 +165,15 @@ myRespXY <- DataSpecies[,c("X_WGS84","Y_WGS84")]
 
 
 # Environmental variables extracted from BIOCLIM (bio_3, bio_4, bio_7, bio_11 & bio_12)
-myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd", 
+myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd",
                              package="biomod2"),
-                system.file( "external/bioclim/current/bio4.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio7.grd", 
-                             package="biomod2"),  
-                system.file( "external/bioclim/current/bio11.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio12.grd", 
+                system.file( "external/bioclim/current/bio4.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio7.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio11.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio12.grd",
                              package="biomod2"))
 
 # 1. Formatting Data
@@ -181,26 +181,26 @@ myBiomodData <- BIOMOD_FormatingData(resp.var = myResp,
                                      expl.var = myExpl,
                                      resp.xy = myRespXY,
                                      resp.name = myRespName)
-                                                                     
+
 # 2. Defining Models Options using default options.
 myBiomodOption <- BIOMOD_ModelingOptions()
 
 # 3. Doing Modelisation
 
-myBiomodModelOut <- BIOMOD_Modeling( myBiomodData, 
-                                       models = c('SRE','RF'), 
-                                       models.options = myBiomodOption, 
-                                       NbRunEval=2, 
-                                       DataSplit=80, 
-                                       VarImport=0, 
+myBiomodModelOut <- BIOMOD_Modeling( myBiomodData,
+                                       models = c('SRE','RF'),
+                                       models.options = myBiomodOption,
+                                       NbRunEval=2,
+                                       DataSplit=80,
+                                       VarImport=0,
                                        models.eval.meth = c('TSS','ROC'),
                                        do.full.models=FALSE,
                                        modeling.id="test")
-                                       
+
 ## print a summary of modeling stuff
 myBiomodModelOut
-                                       
-                                    
+
+
 }
 
 \keyword{ models }

--- a/man/BIOMOD_Modeling.Rd
+++ b/man/BIOMOD_Modeling.Rd
@@ -83,7 +83,7 @@ BIOMOD_Modeling( data,
   \item{\bold{Yweights & Prevalence}}{
 
     Allows to give more or less weight to some particular observations. If these arguments is kept to NULL (\code{Yweights = NULL}, \code{Prevalence = NULL}), each observation (presence or absence) has the same weight (independent of the number of presences and absences). If \code{Prevalence = 0.5} absences will be weighted equally to the presences (i.e. the weighted sum of presence equals the weighted sum of absences). If prevalence is set below or above 0.5 absences or presences are given more weight, respectively.
-In the particular case that pseudo-absence data have been generated \code{BIOMOD_FormatingData} (\code{PA.nb.rep > 0}), weights are by default (\code{Prevalence = NULL}) calculated such that prevalence is 0.5, meaning that the presences will have the same importance as the absences in the calibration process of the models. Automatically created \code{Yweights} will be composed of integers to prevent different modelling issues.
+In the particular case that pseudo-absence data have been generated \code{BIOMOD_FormatingData} (\code{PA.nb.rep > 0}), weights are by default (\code{Prevalence = NULL}) calculated such that prevalence is 0.5, meaning that the presences will have the same importance as the absences in the calibration process of the models. Automatically created \code{Yweights} will be composed of integers to prevent different modeling issues.
 Note that the \code{Prevalence} argument will always be ignored if \code{Yweights} are defined.
 
 
@@ -110,7 +110,7 @@ Note that the \code{Prevalence} argument will always be ignored if \code{Yweight
 
   \item{\bold{SaveObj}}{
 
-  If this argument is set to False, it may prevent the evaluation of the \sQuote{ensemble modelled} models in further steps. We strongly recommend to always keep this argument \code{TRUE} even it asks for free space onto the hard drive.
+  If this argument is set to False, it may prevent the evaluation of the \sQuote{ensemble modeled} models in further steps. We strongly recommend to always keep this argument \code{TRUE} even it asks for free space onto the hard drive.
   }
 
   \item{\bold{rescal.all.models}}{
@@ -121,7 +121,7 @@ Note that the \code{Prevalence} argument will always be ignored if \code{Yweight
 
   \item{\bold{do.full.models}}{
 
-  Building models with all information available may be usefull in some particular cases (i.e. rare species with few presences points). The main drawback of this method is that, if you don't give separated data for models evaluation, your models will be evaluated with the same data that the ones used for calibration. Thats will lead to over-optimistic evaluation scores. Be careful whith this '_Full' models interpretation.
+  Building models with all information available may be useful in some particular cases (i.e. rare species with few presences points). The main drawback of this method is that, if you don't give separated data for models evaluation, your models will be evaluated with the same data that the ones used for calibration. That will lead to over-optimistic evaluation scores. Be careful with this '_Full' models interpretation.
   }
 } % end of enumerate
 } % end of detail

--- a/man/BIOMOD_ModelingOptions.Rd
+++ b/man/BIOMOD_ModelingOptions.Rd
@@ -43,7 +43,7 @@ BIOMOD_ModelingOptions(GLM = NULL,
 A \code{"\link[=BIOMOD.Model.Options-class]{BIOMOD.Model.Options}"} object given to \code{\link[biomod2]{BIOMOD_Modeling}}
 }
 \description{
-Parametrize and/or tune biomod's single models options.
+Parameterize and/or tune biomod's single models options.
 }
 \details{
 The aim of this function is to allow advanced user to change some default parameters of BIOMOD inner models.
@@ -53,7 +53,7 @@ The aim of this function is to allow advanced user to change some default parame
 
   The best way to use this function is to print default models options (\code{\link{Print_Default_ModelingOptions}}) or create a default 'BIOMOD.model.option object' and print it in your console. Then copy the output, change only the required parameters, and paste it as function arguments. (see example)
 
-  Here the detailed list of modifiable parameters. They correspond to the traditional parameters that could be setted out for each modeling technique (e.g. ?GLM)
+  Here the detailed list of modifiable parameters. They correspond to the traditional parameters that could be set out for each modeling technique (e.g. ?GLM)
 }
 \section{GLM (\code{\link[stats]{glm}})}{
 
@@ -69,7 +69,7 @@ The aim of this function is to allow advanced user to change some default parame
           \item{or construct specific formula}
         }}
 
-    \item{\code{test} (default \code{'AIC'}) : Information criteria for the stepwise selection procedure: AIC for Akaike Information Criteria, and BIC for Bayesian Information Criteria ('AIC' or 'BIC'). 'none' is also a supported value which implies to consider only the full model (no stepwise selection). This can lead to convergence issu and strange results.}
+    \item{\code{test} (default \code{'AIC'}) : Information criteria for the stepwise selection procedure: AIC for Akaike Information Criteria, and BIC for Bayesian Information Criteria ('AIC' or 'BIC'). 'none' is also a supported value which implies to consider only the full model (no stepwise selection). This can lead to convergence issues and strange results.}
 
     \item{\code{family} (default \code{binomial(link = 'logit')}) : a description of the error distribution and link function to be used in the model. This can be a character string naming a family function, a family function or the result of a call to a family function. (See \link{family} for details of family functions.) . BIOMOD only runs on presence-absence data so far, so binomial family by default.}
 
@@ -148,8 +148,8 @@ The aim of this function is to allow advanced user to change some default parame
 
   \itemize{
     \item{\code{NbCV} (default \code{5}) : nb of cross validation to find best size and decay parameters}
-    \item{\code{size}} (default \code{NULL}) : number of units in the hidden layer. If \code{NULL} then size parameter will be optimised by cross validation based on model AUC (\code{NbCv} cross validation; tested size will be the following c(2,4,6, 8) ). You can also specified a vector of size you want to test. The one giving the best model AUC will be then selected.
-    \item{\code{decay}} (default \code{NULL}) : parameter for weight decay. If \code{NULL} then decay parameter will be optimised by cross validation on model AUC (\code{NbCv} cross validation; tested decay will be the following c(0.001, 0.01, 0.05, 0.1) ). You can also specified a vector of decay you want to test. The one giving the best model AUC will be then selected.
+    \item{\code{size}} (default \code{NULL}) : number of units in the hidden layer. If \code{NULL} then size parameter will be optimized by cross validation based on model AUC (\code{NbCv} cross validation; tested size will be the following c(2,4,6, 8) ). You can also specified a vector of size you want to test. The one giving the best model AUC will be then selected.
+    \item{\code{decay}} (default \code{NULL}) : parameter for weight decay. If \code{NULL} then decay parameter will be optimized by cross validation on model AUC (\code{NbCv} cross validation; tested decay will be the following c(0.001, 0.01, 0.05, 0.1) ). You can also specified a vector of decay you want to test. The one giving the best model AUC will be then selected.
     \item{\code{rang} (default \code{0.1}) : Initial random weights on [-rang, rang]}
     \item{\code{maxit} (default \code{200}): maximum number of iterations.}
   }
@@ -215,9 +215,9 @@ The aim of this function is to allow advanced user to change some default parame
     \item{\code{path_to_maxent.jar} : character, the link to \pkg{maxent.jar} file (the working directory by default) }
     \item{\code{memory_allocated} : integer (default \code{512}), the amount of memory (in Mo) reserved for java to run MAXENT.Phillips. should be 64, 128, 256, 512, 1024, 2048... or NULL if you want to use default java memory limitation parameter.}
     \item{\code{background_data_dir} : character, path to a directory where explanatory variables are stored as ASCII files (raster format).
-      If specified MAXENT will generate it's own background data from expalantory variables rasters (as usually done in MAXENT studies). If not
+      If specified MAXENT will generate it's own background data from explanatory variables rasters (as usually done in MAXENT studies). If not
       set, then MAXENT will use the same pseudo absences than other models (generated within biomod2 at formatting step) as background data.}
-    \item{\code{maximumbackground} : integer, the maximum nuber of background data to sample. This parameter will be use only if \code{background_data_dir}
+    \item{\code{maximumbackground} : integer, the maximum number of background data to sample. This parameter will be use only if \code{background_data_dir}
       option has been set to a non default value.}
     \item{\code{maximumiterations} : integer (default \code{200}), maximum iteration done}
     \item{\code{visible} : logical (default \code{FALSE}), make the Maxent user interface visible}
@@ -250,7 +250,7 @@ The aim of this function is to allow advanced user to change some default parame
   }
 
   NOTE: if you use the \code{set_heldout} parameter then the data that will be held out will be taken in the
-  calibration data pool. It can be penilizing in case of low number of occurences dataset.
+  calibration data pool. It can be penalizing in case of low number of occurrences dataset.
 }
 \examples{
   ## default BIOMOD.model.option object

--- a/man/BIOMOD_ModelingOptions.Rd
+++ b/man/BIOMOD_ModelingOptions.Rd
@@ -46,41 +46,41 @@ A \code{"\link[=BIOMOD.Model.Options-class]{BIOMOD.Model.Options}"} object given
 Parametrize and/or tune biomod's single models options.
 }
 \details{
-The aim of this function is to allow advanced user to change some default parameters of BIOMOD inner models.  
-  For each modeling technique, options can be set up.  
-  
+The aim of this function is to allow advanced user to change some default parameters of BIOMOD inner models.
+  For each modeling technique, options can be set up.
+
   Each argument have to be put in a list object.
-  
-  The best way to use this function is to print defaut models options (\code{\link{Print_Default_ModelingOptions}}) or create a default 'BIOMOD.model.option object' and print it in your console. Then copy the output, change only the required parameters, and paste it as function arguments. (see example)  
-  
+
+  The best way to use this function is to print default models options (\code{\link{Print_Default_ModelingOptions}}) or create a default 'BIOMOD.model.option object' and print it in your console. Then copy the output, change only the required parameters, and paste it as function arguments. (see example)
+
   Here the detailed list of modifiable parameters. They correspond to the traditional parameters that could be setted out for each modeling technique (e.g. ?GLM)
 }
 \section{GLM (\code{\link[stats]{glm}})}{
 
-  
+
   \itemize{
-    
-    \item{\code{myFormula} : a typical formula object (see example). If not NULL, type and interaction.level args are switched off. 
-      You can choose to either: 
+
+    \item{\code{myFormula} : a typical formula object (see example). If not NULL, type and interaction.level args are switched off.
+      You can choose to either:
         \itemize{
-          \item{generate automatically the GLM formula by using the type and interaction.level arguments 
-            type (default \code{'quadratic'}) : formula given to the model ('simple', 'quadratic' or 'polynomial'). 
+          \item{generate automatically the GLM formula by using the type and interaction.level arguments
+            type (default \code{'quadratic'}) : formula given to the model ('simple', 'quadratic' or 'polynomial').
             interaction.level (default \code{0}) : integer corresponding to the interaction level between variables considered. Consider that interactions quickly enlarge the number of effective variables used into the GLM.}
           \item{or construct specific formula}
         }}
-    
-    \item{\code{test} (default \code{'AIC'}) : Information criteria for the stepwise selection procedure: AIC for Akaike Information Criteria, and BIC for Bayesian Information Criteria ('AIC' or 'BIC'). 'none' is also a supported value which implies to concider only the full model (no stepwise selection). This can lead to convergence issu and strange results.}
-    
+
+    \item{\code{test} (default \code{'AIC'}) : Information criteria for the stepwise selection procedure: AIC for Akaike Information Criteria, and BIC for Bayesian Information Criteria ('AIC' or 'BIC'). 'none' is also a supported value which implies to consider only the full model (no stepwise selection). This can lead to convergence issu and strange results.}
+
     \item{\code{family} (default \code{binomial(link = 'logit')}) : a description of the error distribution and link function to be used in the model. This can be a character string naming a family function, a family function or the result of a call to a family function. (See \link{family} for details of family functions.) . BIOMOD only runs on presence-absence data so far, so binomial family by default.}
-    
+
     \item{\code{control} : a list of parameters for controlling the fitting process. For glm.fit this is passed to \code{\link{glm.control}}.}
-    
+
   }
 }
 
 \section{GBM (default \code{\link[gbm]{gbm}})}{
 
-  
+
   Please refer to \code{\link[gbm]{gbm}} help file to get the meaning of this options.
   \itemize{
     \item{ \code{distribution} (default \code{'bernoulli'})}
@@ -100,22 +100,22 @@ The aim of this function is to allow advanced user to change some default parame
 \section{GAM (\code{\link[gam]{gam}} or \code{\link[mgcv]{gam}})}{
 
   \itemize{
-    
+
     \item{algo : either "GAM_gam" (default), "GAM_mgcv" or "BAM_mgcv" defining the chosen GAM function (see \code{\link[mgcv]{gam}}, \code{\link[gam]{gam}} resp. \code{\link[mgcv]{bam}} for more details)}
-    
-    \item{\code{myFormula} : a typical formula object (see example). If not NULL, type and interaction.level args are switched off. 
-      You can choose to either: 
+
+    \item{\code{myFormula} : a typical formula object (see example). If not NULL, type and interaction.level args are switched off.
+      You can choose to either:
         \itemize{
-          \item{generate automatically the GAM formula by using the type and interaction.level arguments 
-            type : the smother used to generate the formula. Only "s_smoother" available at time. 
-            interaction.level : integer corresponding to the interaction level between variables considered. Consider that interactions quickly enlarge the number of effective variables used into the GAM. Interaction are not considered if you choosed "GAM_gam" algo}
+          \item{generate automatically the GAM formula by using the type and interaction.level arguments
+            type : the smother used to generate the formula. Only "s_smoother" available at time.
+            interaction.level : integer corresponding to the interaction level between variables considered. Consider that interactions quickly enlarge the number of effective variables used into the GAM. Interaction are not considered if you chose "GAM_gam" algo}
           \item{or construct specific formula}
         }}
-    
+
     \item{k (default \code{-1} or \code{4}): a smooth term in a formula argument to gam (see \pkg{gam} \code{\link[gam]{s}} or \pkg{mgcv} \code{\link[mgcv]{s}})}
     \item{family (default \code{binomial(link = 'logit')}) : a description of the error distribution and link function to be used in the model. This can be a character string naming a family function, a family function or the result of a call to a family function. (See \link{family} for details of family functions.) . BIOMOD only runs on presence-absence data so far, so binomial family by default. }
     \item{control : see \code{\link[mgcv]{gam.control}} or \code{\link[gam]{gam.control}}}
-    
+
     \item{some extra "GAM_mgcv" specific options (ignored if algo = "GAM_gam")
       \itemize{
         \item{\code{method} (default \code{'GCV.Cp'})}
@@ -124,14 +124,14 @@ The aim of this function is to allow advanced user to change some default parame
         \item{\code{knots} (default \code{NULL})}
         \item{\code{paramPen} (default \code{NULL})}
       }
-      
+
     }
   }
 }
 
 \section{CTA (\code{\link[rpart]{rpart}})}{
 
-  
+
   Please refer to \code{\link[rpart]{rpart}} help file to get the meaning of the following options.
   \itemize{
     \item{\code{method} (default \code{'class'})}
@@ -139,13 +139,13 @@ The aim of this function is to allow advanced user to change some default parame
     \item{\code{cost} (default \code{NULL})}
     \item{\code{control}: see \code{\link[rpart]{rpart.control}}}
   }
-  
+
   NOTE: for method and parms, you can give a 'real' value as described in the rpart help file or 'default' that implies default \code{\link[rpart]{rpart}} values.
 }
 
 \section{ANN (\code{\link[nnet]{nnet}})}{
 
-  
+
   \itemize{
     \item{\code{NbCV} (default \code{5}) : nb of cross validation to find best size and decay parameters}
     \item{\code{size}} (default \code{NULL}) : number of units in the hidden layer. If \code{NULL} then size parameter will be optimised by cross validation based on model AUC (\code{NbCv} cross validation; tested size will be the following c(2,4,6, 8) ). You can also specified a vector of size you want to test. The one giving the best model AUC will be then selected.
@@ -164,25 +164,25 @@ The aim of this function is to allow advanced user to change some default parame
 
 \section{FDA (\code{\link[mda]{fda}})}{
 
-  
+
   Please refer to \code{\link[mda]{fda}} help file to get the meaning of these options.
   \itemize{
     \item{\code{method} (default \code{'mars'})}
     \item{\code{add_args} (default \code{NULL}) : additional arguments to \code{method} given as a list of parameters
-      (corespond to the \ldots options of fda function) }
+      (correspond to the \ldots options of fda function) }
   }
 }
 
 \section{MARS (\code{\link[earth]{earth}})}{
 
-  
+
   Please refer to \code{\link[earth]{earth}} help file to get the meaning of these options.
   \itemize{
-    \item{\code{myFormula} : a typical formula object (see example). If not NULL, type and interaction.level args are switched off. 
-      You can choose to either: 
+    \item{\code{myFormula} : a typical formula object (see example). If not NULL, type and interaction.level args are switched off.
+      You can choose to either:
         \itemize{
-          \item{generate automatically the GLM formula by using the type and interaction.level arguments 
-            type (default \code{'simple'}) : formula given to the model ('simple', 'quadratic' or 'polynomial'). 
+          \item{generate automatically the GLM formula by using the type and interaction.level arguments
+            type (default \code{'simple'}) : formula given to the model ('simple', 'quadratic' or 'polynomial').
             interaction.level (default \code{0}) : integer corresponding to the interaction level between variables considered. Consider that interactions quickly enlarge the number of effective variables used into the GLM/MARS.}
           \item{or construct specific formula}
         }}
@@ -197,7 +197,7 @@ The aim of this function is to allow advanced user to change some default parame
 
 \section{RF (\code{\link[randomForest]{randomForest}})}{
 
-  
+
   \itemize{
     \item{\code{do.classif} (default \code{TRUE}) : if TRUE classification random.forest computed else regression random.forest will be done}
     \item{\code{ntree} (default \code{500})}
@@ -205,7 +205,7 @@ The aim of this function is to allow advanced user to change some default parame
     \item{\code{nodesize} (default \code{5})}
     \item{\code{maxnodes} (default \code{NULL})}
   }
-  
+
   NOTE: for mtry, you can give a 'real' value as described in randomForest help file or 'default' that implies default randomForest values
 }
 
@@ -214,8 +214,8 @@ The aim of this function is to allow advanced user to change some default parame
   \itemize{
     \item{\code{path_to_maxent.jar} : character, the link to \pkg{maxent.jar} file (the working directory by default) }
     \item{\code{memory_allocated} : integer (default \code{512}), the amount of memory (in Mo) reserved for java to run MAXENT.Phillips. should be 64, 128, 256, 512, 1024, 2048... or NULL if you want to use default java memory limitation parameter.}
-    \item{\code{background_data_dir} : character, path to a directory where explanatory variables are stored as ASCII files (raster format). 
-      If specified MAXENT will generate it's own background data from expalantory variables rasters (as usually done in MAXENT studies). If not 
+    \item{\code{background_data_dir} : character, path to a directory where explanatory variables are stored as ASCII files (raster format).
+      If specified MAXENT will generate it's own background data from expalantory variables rasters (as usually done in MAXENT studies). If not
       set, then MAXENT will use the same pseudo absences than other models (generated within biomod2 at formatting step) as background data.}
     \item{\code{maximumbackground} : integer, the maximum nuber of background data to sample. This parameter will be use only if \code{background_data_dir}
       option has been set to a non default value.}
@@ -240,7 +240,7 @@ The aim of this function is to allow advanced user to change some default parame
 
 \section{MAXENT.Tsuruoka (\code{\link[maxent]{maxent}})}{
 
-  
+
   \itemize{
     \item{\code{l1_regularizer} (default \code{0.0}): An numeric turning on L1 regularization and setting the regularization parameter. A value of 0 will disable L1 regularization}
     \item{\code{l2_regularizer} (default \code{0.0}): An numeric turning on L2 regularization and setting the regularization parameter. A value of 0 will disable L2 regularization}
@@ -248,18 +248,18 @@ The aim of this function is to allow advanced user to change some default parame
     \item{\code{set_heldout} (default \code{0}): An integer specifying the number of documents to hold out. Sets a held-out subset of your data to test against and prevent overfitting}
     \item{\code{verbose} (default \code{FALSE}): A logical specifying whether to provide descriptive output about the training process}
   }
-  
-  NOTE: if you use the \code{set_heldout} parameter then the data that will be held out will be taken in the 
+
+  NOTE: if you use the \code{set_heldout} parameter then the data that will be held out will be taken in the
   calibration data pool. It can be penilizing in case of low number of occurences dataset.
 }
 \examples{
   ## default BIOMOD.model.option object
   myBiomodOptions <- BIOMOD_ModelingOptions()
-  
+
   ## print the object
   myBiomodOptions
-  
-  ## you can copy a part of the print, change it and custom your options 
+
+  ## you can copy a part of the print, change it and custom your options
   ## here we want to compute quadratic GLM and select best model with 'BIC' criterium
   myBiomodOptions <- BIOMOD_ModelingOptions(
     GLM = list( type = 'quadratic',
@@ -267,24 +267,24 @@ The aim of this function is to allow advanced user to change some default parame
                 myFormula = NULL,
                 test = 'BIC',
                 family = 'binomial',
-                control = glm.control(epsilon = 1e-08, 
-                                      maxit = 1000, 
+                control = glm.control(epsilon = 1e-08,
+                                      maxit = 1000,
                                       trace = FALSE) ))
-  
+
   ## check changes was done
   myBiomodOptions
-  
+
   ##' you can prefer to establish your own GLM formula
   myBiomodOptions <- BIOMOD_ModelingOptions(
-    GLM = list( myFormula = formula("Sp277 ~ bio3 + 
+    GLM = list( myFormula = formula("Sp277 ~ bio3 +
                     log(bio10) + poly(bio16,2) + bio19 + bio3:bio19")))
-  
+
   ## check changes was done
   myBiomodOptions
-  
+
   ##' you also can directly print default parameters and then follow the same processus
   Print_Default_ModelingOptions()
-  
+
 }
 \author{
 Damien Georges, Wilfried Thuiller

--- a/man/BIOMOD_Projection.Rd
+++ b/man/BIOMOD_Projection.Rd
@@ -62,7 +62,7 @@ If \code{build.clamping.mask} is set to \code{TRUE} a file (same type than \code
 \value{
 Returns the projections for all selected model (\code{"\link[=BIOMOD.projection.out-class]{BIOMOD.projection.out}"} object), and stored in the hard drive on the specific directory names by the name of the projection. The data is a 4-dimensions array (see ...) if new.env is a \code{matrix} or a \code{data.frame}. It is a rasterStack if new.env is a \code{rasterStack} and or several rasterLayers if the \code{rasterStack} is too large.
 
-A new folder is also created on your hard drive. This folder contains the created projection object (basic one and binary and filtered ones if selected). The object are loaded with the \code{\link{load}} function. The loaded object can be then plotted and analysed.
+A new folder is also created on your hard drive. This folder contains the created projection object (basic one and binary and filtered ones if selected). The object are loaded with the \code{\link{load}} function. The loaded object can be then plotted and analyzed.
 
 }
 
@@ -83,7 +83,7 @@ head(DataSpecies)
 # the name of studied species
 myRespName <- 'GuloGulo'
 
-# the presence/absences data for our species 
+# the presence/absences data for our species
 myResp <- as.numeric(DataSpecies[,myRespName])
 
 # the XY coordinates of species data
@@ -91,15 +91,15 @@ myRespXY <- DataSpecies[,c("X_WGS84","Y_WGS84")]
 
 
 # Environmental variables extracted from BIOCLIM (bio_3, bio_4, bio_7, bio_11 & bio_12)
-myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd", 
+myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd",
                      package="biomod2"),
-                system.file( "external/bioclim/current/bio4.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio7.grd", 
-                             package="biomod2"),  
-                system.file( "external/bioclim/current/bio11.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio12.grd", 
+                system.file( "external/bioclim/current/bio4.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio7.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio11.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio12.grd",
                              package="biomod2"))
 # 1. Formatting Data
 myBiomodData <- BIOMOD_FormatingData(resp.var = myResp,
@@ -112,10 +112,10 @@ myBiomodOption <- BIOMOD_ModelingOptions()
 
 # 3. Doing Modelisation
 
-myBiomodModelOut <- BIOMOD_Modeling( myBiomodData, 
-                                       models = c('SRE','RF'), 
-                                       models.options = myBiomodOption, 
-                                       NbRunEval=1, 
+myBiomodModelOut <- BIOMOD_Modeling( myBiomodData,
+                                       models = c('SRE','RF'),
+                                       models.options = myBiomodOption,
+                                       NbRunEval=1,
                                        DataSplit=70,
                                        models.eval.meth = c('TSS'),
                                        do.full.models = FALSE)
@@ -151,7 +151,7 @@ myBiomodProjectionFuture <- BIOMOD_Projection(modeling.output = myBiomodModelOut
 myBiomodProjectionFuture
 plot(myBiomodProjectionFuture)
 }
-                                       
+
 }
 \keyword{ models }
 \keyword{ regression }

--- a/man/BIOMOD_RangeSize.Rd
+++ b/man/BIOMOD_RangeSize.Rd
@@ -12,7 +12,7 @@
 \title{ Analysis of the range size changes }
 \description{
   This function allows to estimate the proportion and relative number of pixels (or habitat) lost, gained
-and stable for the time slice considered in species-climate modelling under future scenarios.
+and stable for the time slice considered in species-climate modeling under future scenarios.
 }
 \usage{
 
@@ -29,8 +29,8 @@ and stable for the time slice considered in species-climate modelling under futu
 }
 
 \arguments{
-  \item{CurrentPred}{ a data.frame of n (number of models) columns OR an array formated as an output of \code{\link[biomod2]{BIOMOD_Projection}} function OR a \code{RasterStack} (a layer by model) giving the current state of the species in binary  }
-  \item{FutureProj}{ a data.frame of n (number of models) columns OR an array formated as an output of \code{\link[biomod2]{BIOMOD_Projection}} function OR a \code{RasterStack} (a layer by model) giving the future projections of the species in binary according to a future scenario}
+  \item{CurrentPred}{ a data.frame of n (number of models) columns OR an array formatted as an output of \code{\link[biomod2]{BIOMOD_Projection}} function OR a \code{RasterStack} (a layer by model) giving the current state of the species in binary  }
+  \item{FutureProj}{ a data.frame of n (number of models) columns OR an array formatted as an output of \code{\link[biomod2]{BIOMOD_Projection}} function OR a \code{RasterStack} (a layer by model) giving the future projections of the species in binary according to a future scenario}
   \item{SpChange.Save}{ the name given to the new object storing the results }
 }
 \details{
@@ -51,9 +51,9 @@ and stable for the time slice considered in species-climate modelling under futu
   For example, if the there are 30 sites currently occupied and 15 new sites are projected to be occupied in future, it makes PercGain=+50(\%).}
   \item{    SpeciesRangeChange}{ it is the overall projection outcome, equal to PercGain-PercLoss. It does not assess for any migration shifts as it
   strictly compares the range sizes between current and future states.}
-  \item{    CurrentRangeSize}{ represents the modelled current range size (number of pixels occupied) of the given species.}
-  \item{    FutureRangeSize0Disp}{ represents the future modelled range size assuming no migration of the given species.}
-  \item{    FutureRangeSize1Disp}{ represents the future modelled range size assuming migration of the given species (depending on the datasets given in input, if Migration has been used or not).}
+  \item{    CurrentRangeSize}{ represents the modeled current range size (number of pixels occupied) of the given species.}
+  \item{    FutureRangeSize0Disp}{ represents the future modeled range size assuming no migration of the given species.}
+  \item{    FutureRangeSize1Disp}{ represents the future modeled range size assuming migration of the given species (depending on the datasets given in input, if Migration has been used or not).}
   
   \item{Diff.By.Pixel}{ the summary of range change for each species (sorted by columns and with the pixel
   in rows). For each species, a pixel could have four different values :

--- a/man/BIOMOD_cv.Rd
+++ b/man/BIOMOD_cv.Rd
@@ -20,7 +20,7 @@ BIOMOD_cv(data, k = 5, repetition = 5, do.full.models = TRUE,
 
 \item{stratify}{stratification method of the cv. Could be "x", "y", "both" (default), "block" or the name of a predictor for environmental stratified cv.}
 
-\item{balance}{make balanced particions for "presences" (default) or "absences" (resp. pseudo-absences or background).}
+\item{balance}{make balanced partitions for "presences" (default) or "absences" (resp. pseudo-absences or background).}
 }
 \value{
 DataSplitTable matrix with k*repetition (+ 1 for Full models if  do.full.models = TRUE) columns for BIOMOD_Modeling function.
@@ -33,11 +33,11 @@ This function creates a DataSplitTable which could be used to evaluate models in
 }
 \details{
 Stratified cv could be used to test for model overfitting and for assessing transferability in geographic and environmental space. 
-  If balance = "presences" presences are divided (balanced) equally over the particions (e.g. Fig. 1b in Muscarelly et al. 2014).
+  If balance = "presences" presences are divided (balanced) equally over the partitions (e.g. Fig. 1b in Muscarelly et al. 2014).
   Pseudo-Absences will however be unbalanced over the particions especially if the presences are clumped on an edge of the study area.
   If balance = "absences" absences (resp. Pseudo-Absences or background) are divided (balanced) as equally as possible for the particions
   (geographical balanced bins given that absences are spread over the study area equally, approach similar to Fig. 1 in Wenger et Olden 2012).
-  Presences will however be unbalanced over the particians. Be careful: If the presences are clumped on an edge of the study area it is possible that all presences are in one bin.
+  Presences will however be unbalanced over the partitions. Be careful: If the presences are clumped on an edge of the study area it is possible that all presences are in one bin.
 }
 \examples{
 \dontrun{

--- a/man/BIOMOD_presenceonly.Rd
+++ b/man/BIOMOD_presenceonly.Rd
@@ -25,7 +25,7 @@ BIOMOD.EnsembleModeling.out object with presence-only evaluation methods
 }
 \details{
 'em.by' of 'BIOMOD.EnsembleModeling' must be 'PA_dataset+repet' to have an 
-ensemble for each RUN of the 'NbRunEval' argument (BIOMOD_Modeling funtion)
+ensemble for each RUN of the 'NbRunEval' argument (BIOMOD_Modeling function)
 for evaluation.
 The Boyce index returns NA values for 'SRE' models because it is not possible
 to be calculated with binary predictions. This is also the reason why there 

--- a/man/BIOMOD_tuning.Rd
+++ b/man/BIOMOD_tuning.Rd
@@ -15,7 +15,7 @@ tuning.maxent(occ, env = NULL, pres = NULL, bg = NULL, bg.coords = NULL,
 \arguments{
 \item{data}{BIOMOD.formated.data object returned by BIOMOD_FormatingData}
 
-\item{models}{vector of models names choosen among 'GLM', 'GBM', 'GAM', 'CTA', 'ANN', 'SRE', 'FDA', 'MARS', 'RF', 'MAXENT.Phillips' and 'MAXENT.Tsuruoka'}
+\item{models}{vector of models names chosen among 'GLM', 'GBM', 'GAM', 'CTA', 'ANN', 'SRE', 'FDA', 'MARS', 'RF', 'MAXENT.Phillips' and 'MAXENT.Tsuruoka'}
 
 \item{models.options}{BIOMOD.models.options object returned by BIOMOD_ModelingOptions. Default: BIOMOD_ModelingOptions()}
 
@@ -53,7 +53,7 @@ tuning.maxent(occ, env = NULL, pres = NULL, bg = NULL, bg.coords = NULL,
 
 \item{method.GLM}{which classification or regression model to use for GLM: (default: 'glmStepAIC'). see http://topepo.github.io/caret/Generalized_Linear_Model.html}
 
-\item{type.GLM}{vector of modeling types choosen among 'simple', 'quadratic', 'polynomial' or 's_smoother' (default c('simple','quadratic','polynomial','s_smoother'))}
+\item{type.GLM}{vector of modeling types chosen among 'simple', 'quadratic', 'polynomial' or 's_smoother' (default c('simple','quadratic','polynomial','s_smoother'))}
 
 \item{interaction.GLM}{vector of interaction type choosen among 0, 1. Default c(0,1)}
 
@@ -97,22 +97,22 @@ head(DataSpecies)
 # the name of studied species
 myRespName <- 'GuloGulo'
 
-# the presence/absences data for our species 
+# the presence/absences data for our species
 myResp <- as.numeric(DataSpecies[,myRespName])
 
 # the XY coordinates of species data
 myRespXY <- DataSpecies[,c("X_WGS84","Y_WGS84")]
 
 # Environmental variables extracted from BIOCLIM (bio_3, bio_4, bio_7, bio_11 & bio_12)
-myExpl = stack( system.file( "external/bioclim/current/bio3.grd", 
+myExpl = stack( system.file( "external/bioclim/current/bio3.grd",
                              package="biomod2"),
-                system.file( "external/bioclim/current/bio4.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio7.grd", 
-                             package="biomod2"),  
-                system.file( "external/bioclim/current/bio11.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio12.grd", 
+                system.file( "external/bioclim/current/bio4.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio7.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio11.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio12.grd",
                              package="biomod2"))
 # 1. Formatting Data
 myBiomodData <- BIOMOD_FormatingData(resp.var = myResp,
@@ -121,11 +121,11 @@ myBiomodData <- BIOMOD_FormatingData(resp.var = myResp,
                                      resp.name = myRespName)
 
 # 2. Defining Models Options using default options.
-### Duration for turing all models sequential with default settings 
+### Duration for turing all models sequential with default settings
 ### on 3.4 GHz processor: approx. 45 min tuning all models in parallel
 ### (on 8 cores) using foreach loops runs much faster: approx. 14 min
 
-#library(doParallel);cl<-makeCluster(8);registerDoParallel(cl) 
+#library(doParallel);cl<-makeCluster(8);registerDoParallel(cl)
 
 
 time.seq<-system.time(Biomod.tuning <- BIOMOD_tuning(myBiomodData,
@@ -133,12 +133,12 @@ time.seq<-system.time(Biomod.tuning <- BIOMOD_tuning(myBiomodData,
                                                              n.bg.ME = ncell(myExpl)))
 #stopCluster(cl)
 
-myBiomodModelOut <- BIOMOD_Modeling( myBiomodData, 
-                                     models = c('RF','CTA'), 
-                                     models.options = Biomod.tuning$models.options, 
-                                     NbRunEval=1, 
-                                     DataSplit=100, 
-                                     VarImport=0, 
+myBiomodModelOut <- BIOMOD_Modeling( myBiomodData,
+                                     models = c('RF','CTA'),
+                                     models.options = Biomod.tuning$models.options,
+                                     NbRunEval=1,
+                                     DataSplit=100,
+                                     VarImport=0,
                                      models.eval.meth = c('ROC'),
                                      do.full.models=FALSE,
                                      modeling.id="test")

--- a/man/BIOMOD_tuning.Rd
+++ b/man/BIOMOD_tuning.Rd
@@ -19,7 +19,7 @@ tuning.maxent(occ, env = NULL, pres = NULL, bg = NULL, bg.coords = NULL,
 
 \item{models.options}{BIOMOD.models.options object returned by BIOMOD_ModelingOptions. Default: BIOMOD_ModelingOptions()}
 
-\item{trControl}{global control parameters for runing (default trainControl(method="cv",summaryFunction=twoClassSummary,classProbs=T),returnData = FALSE). for details see trainControl}
+\item{trControl}{global control parameters for running (default trainControl(method="cv",summaryFunction=twoClassSummary,classProbs=T),returnData = FALSE). for details see trainControl}
 
 \item{ctrl.GAM}{specify control parameters only for GAM (default trControl)}
 
@@ -55,7 +55,7 @@ tuning.maxent(occ, env = NULL, pres = NULL, bg = NULL, bg.coords = NULL,
 
 \item{type.GLM}{vector of modeling types chosen among 'simple', 'quadratic', 'polynomial' or 's_smoother' (default c('simple','quadratic','polynomial','s_smoother'))}
 
-\item{interaction.GLM}{vector of interaction type choosen among 0, 1. Default c(0,1)}
+\item{interaction.GLM}{vector of interaction type chosen among 0, 1. Default c(0,1)}
 
 \item{cvmethod.ME}{method used for data partitioning for MAXENT.Phillips (default: 'randomkfold')}
 
@@ -69,9 +69,9 @@ tuning.maxent(occ, env = NULL, pres = NULL, bg = NULL, bg.coords = NULL,
 
 \item{env.ME}{RasterStack of model predictor variables}
 
-\item{size.tune.ANN}{size parameters (number of units in the hidden layer) for ANN used for tuning (default: c(2,4,6,8)).  Will be optimised using the method specified in ctrl.ANN (if not available trControl).}
+\item{size.tune.ANN}{size parameters (number of units in the hidden layer) for ANN used for tuning (default: c(2,4,6,8)).  Will be optimized using the method specified in ctrl.ANN (if not available trControl).}
 
-\item{decay.tune.ANN}{weight decay parameters used for tuning for ANN (default: c(0.001, 0.01, 0.05, 0.1))  Will be optimised by method specified in ctrl.ANN (if not available trControl).}
+\item{decay.tune.ANN}{weight decay parameters used for tuning for ANN (default: c(0.001, 0.01, 0.05, 0.1))  Will be optimized by method specified in ctrl.ANN (if not available trControl).}
 
 \item{maxit.ANN}{maximum number of iterations for ANN (default 500)}
 

--- a/man/CustomIndexMaker.Rd
+++ b/man/CustomIndexMaker.Rd
@@ -18,7 +18,7 @@ CustomIndexMaker()
 } %end detail section
 
 \value{
-  A \code{logical} specifying if operation succed or not
+  A \code{logical} specifying if operation succeed or not
 }
 
 \author{ Wilfried Thuiller, Damien Georges }

--- a/man/FilteringTransformation.Rd
+++ b/man/FilteringTransformation.Rd
@@ -71,7 +71,7 @@ In the particular case that the data to convert is a \code{matrix}/\code{data.fr
 
 
 \value{
-An object of the same class than \code{data} with the values of data if suprerior to \code{threshold} and 0 if not.    
+An object of the same class than \code{data} with the values of data if superior to \code{threshold} and 0 if not.    
 }
 
 

--- a/man/Find.Optim.Stat.Rd
+++ b/man/Find.Optim.Stat.Rd
@@ -18,7 +18,7 @@ Find.Optim.Stat(Stat='TSS',
 
 \item{Obs}{vector of observed values (binary)}
 
-\item{Nb.thresh.test}{integer, the numer of thresholds tested over the 
+\item{Nb.thresh.test}{integer, the number of thresholds tested over the 
 range of fitted value}
 
 \item{Fixed.thresh}{integer, if not \code{NULL}, the only threshold value tested}
@@ -39,7 +39,7 @@ to the best score for a given evaluation metric.
 }
 \details{
 Please refer to \code{\link[biomod2]{BIOMOD_Modeling}} to get more information about this metrics.
-  If you give a \code{Fixed.thresh}, no optimisation will be done. Only the score for this threshold will be returned.
+  If you give a \code{Fixed.thresh}, no optimization will be done. Only the score for this threshold will be returned.
 }
 \examples{
   a <- sample(c(0,1),100, replace=TRUE)

--- a/man/Print_Default_ModelingOptions.Rd
+++ b/man/Print_Default_ModelingOptions.Rd
@@ -11,7 +11,7 @@ Print_Default_ModelingOptions()
 }
 
 \details{
-This function is useful to parameterize the selected models. It gives a formated list of all parameters the user can modify. You can copy this function output, modify all parameters you want in a text editor and paste the modified string as argument to (\link{BIOMOD_ModelingOptions}) function.
+This function is useful to parameterize the selected models. It gives a formatted list of all parameters the user can modify. You can copy this function output, modify all parameters you want in a text editor and paste the modified string as argument to (\link{BIOMOD_ModelingOptions}) function.
 }
 
 \value{ 

--- a/man/ProbDensFunc.Rd
+++ b/man/ProbDensFunc.Rd
@@ -4,7 +4,7 @@
 \title{ Probability Density Function }
 \description{
   Using a variety of parameters in modelling will inevitably bring variability in predictions, especially when it comes to making future predictions.
-  This function enables an overall viewing of the future predictions range per species and gives the likelihood of range shift estimations. It will calculate the optimal way for condensing a difined proportion (50, 75, 90 and 95\% per default) of the data. 
+  This function enables an overall viewing of the future predictions range per species and gives the likelihood of range shift estimations. It will calculate the optimal way for condensing a difined proportion (50, 75, 90 and 95\% per default) of the data.
 }
 \usage{
 ProbDensFunc(initial,
@@ -32,11 +32,11 @@ ProbDensFunc(initial,
 }
 
 \details{
-  The future range changes are calculated as a percentage of the species' present state. For example, if a species currently occupies 100 cells and 
+  The future range changes are calculated as a percentage of the species' present state. For example, if a species currently occupies 100 cells and
   is estimated by a model to cover 120 cells in the future, the range change will be + 20\%.
 
   Resolution : Note that modifying the resolution will directly influence the probability scale. Bigger classes will
-  cumulate a greater number of predictions and therefore represent a greater fraction of the total
+  accumulate a greater number of predictions and therefore represent a greater fraction of the total
   predictions. The probability is in fact that of the class and not of isolated events.
 }
 \value{
@@ -56,7 +56,7 @@ head(DataSpecies)
 # the name of studied species
 myRespName <- 'GuloGulo'
 
-# the presence/absences data for our species 
+# the presence/absences data for our species
 myResp <- as.numeric(DataSpecies[,myRespName])
 
 # remove all 0 from response vector to work with
@@ -69,16 +69,16 @@ myResp <- myResp[-rm_id]
 myRespXY <- DataSpecies[-rm_id,c("X_WGS84","Y_WGS84")]
 
 
-# Environmental variables extracted from BIOCLIM 
-myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd", 
+# Environmental variables extracted from BIOCLIM
+myExpl = raster::stack( system.file( "external/bioclim/current/bio3.grd",
                              package="biomod2"),
-                system.file( "external/bioclim/current/bio4.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio7.grd", 
-                             package="biomod2"),  
-                system.file( "external/bioclim/current/bio11.grd", 
-                             package="biomod2"), 
-                system.file( "external/bioclim/current/bio12.grd", 
+                system.file( "external/bioclim/current/bio4.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio7.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio11.grd",
+                             package="biomod2"),
+                system.file( "external/bioclim/current/bio12.grd",
                              package="biomod2"))
 
 # 1. Formatting Data
@@ -92,11 +92,11 @@ myBiomodData <- BIOMOD_FormatingData(resp.var = myResp,
 myBiomodOption <- BIOMOD_ModelingOptions()
 
 # 3. Doing Modelisation
-myBiomodModelOut <- BIOMOD_Modeling( myBiomodData, 
-                                     models = c('CTA','RF','GLM','GAM','ANN','MARS'), 
-                                     models.options = myBiomodOption, 
-                                     NbRunEval=5, 
-                                     DataSplit=70, 
+myBiomodModelOut <- BIOMOD_Modeling( myBiomodData,
+                                     models = c('CTA','RF','GLM','GAM','ANN','MARS'),
+                                     models.options = myBiomodOption,
+                                     NbRunEval=5,
+                                     DataSplit=70,
                                      Prevalence=0.5,
                                      models.eval.meth = c('TSS'),
                                      do.full.models = FALSE,
@@ -114,16 +114,16 @@ myBiomodEM <- BIOMOD_EnsembleModeling( modeling.output = myBiomodModelOut,
 
 # 5. Projection on future environmental conditions
 
-## load future environmental conditions from biomod2 package 
-myExpl_fut <- raster::stack( system.file( "external/bioclim/future/bio3.grd", 
+## load future environmental conditions from biomod2 package
+myExpl_fut <- raster::stack( system.file( "external/bioclim/future/bio3.grd",
                                   package="biomod2"),
-                     system.file( "external/bioclim/future/bio4.grd", 
-                                  package="biomod2"), 
-                     system.file( "external/bioclim/future/bio7.grd", 
-                                  package="biomod2"),  
-                     system.file( "external/bioclim/future/bio11.grd", 
-                                  package="biomod2"), 
-                     system.file( "external/bioclim/future/bio12.grd", 
+                     system.file( "external/bioclim/future/bio4.grd",
+                                  package="biomod2"),
+                     system.file( "external/bioclim/future/bio7.grd",
+                                  package="biomod2"),
+                     system.file( "external/bioclim/future/bio11.grd",
+                                  package="biomod2"),
+                     system.file( "external/bioclim/future/bio12.grd",
                                   package="biomod2"))
 
 myBiomodProjection <- BIOMOD_Projection(modeling.output = myBiomodModelOut,
@@ -150,19 +150,19 @@ find_groups <- function(diff_by_pix){
   data.set <- sapply(names(diff_by_pix),biomod2:::.extractModelNamesInfo,info='data.set')
   run.eval <- sapply(names(diff_by_pix),biomod2:::.extractModelNamesInfo,info='run.eval')
   models <- sapply(names(diff_by_pix),biomod2:::.extractModelNamesInfo,info='models')
-  return(rbind(data.set,run.eval,models))  
+  return(rbind(data.set,run.eval,models))
 }
 
 groups <- find_groups(projectionsBin)
 
 # 9. plot ProbDensFunct graphs
 ProbDensFunc(initial = ref,
-             projections = projectionsBin, 
-             plothist=TRUE, 
-             cvsn=TRUE, 
-             groups=groups, 
-             resolution=2, 
-             filename=NULL, 
+             projections = projectionsBin,
+             plothist=TRUE,
+             cvsn=TRUE,
+             groups=groups,
+             resolution=2,
+             filename=NULL,
              lim=c(0.5,0.8,0.95))
 
 ## 3 plots should be produced.. Should be convenient to save it within a device

--- a/man/ProbDensFunc.Rd
+++ b/man/ProbDensFunc.Rd
@@ -4,7 +4,7 @@
 \title{ Probability Density Function }
 \description{
   Using a variety of parameters in modelling will inevitably bring variability in predictions, especially when it comes to making future predictions.
-  This function enables an overall viewing of the future predictions range per species and gives the likelihood of range shift estimations. It will calculate the optimal way for condensing a difined proportion (50, 75, 90 and 95\% per default) of the data.
+  This function enables an overall viewing of the future predictions range per species and gives the likelihood of range shift estimations. It will calculate the optimal way for condensing a defined proportion (50, 75, 90 and 95\% per default) of the data.
 }
 \usage{
 ProbDensFunc(initial,
@@ -23,11 +23,11 @@ ProbDensFunc(initial,
   \item{cvsn}{ stands for "current vs new". If true, the range change calculations will be of two types: the percentage of cells currently occupied by the species to be lost, and the relative percentage of cells currently unoccupied but projected to be, namely 'new' cells, compared to current surface range.}
   \item{groups}{ an option for ungrouping the projections enabling a separated visualisation of the prediction range per given group. A matrix is expected where each column is a single prediction and each line is giving details of one parameter (See the examples section). }
   \item{resolution}{ the step used for classes of prediction in graphics. The default value is 5 }
-  \item{filename}{ the name of file (with extension) where plots will be stored. If not \code{NULL}, no ploting windows will be open}
-  \item{...}{futher arguments:
+  \item{filename}{ the name of file (with extension) where plots will be stored. If not \code{NULL}, no plotting windows will be open}
+  \item{...}{further arguments:
     \itemize{
-      \item{\code{lim}: ordered numeric vector indicating the proportion of data to consider for histogramme representation (by default : c(0.5,0.75,0.9,0.95) )}
-      \item{\code{nb.points.max}: the maximum number of points to sample, 25000 by default (usefull for huge \code{raster*} objects)}
+      \item{\code{lim}: ordered numeric vector indicating the proportion of data to consider for histogram representation (by default : c(0.5,0.75,0.9,0.95) )}
+      \item{\code{nb.points.max}: the maximum number of points to sample, 25000 by default (useful for huge \code{raster*} objects)}
     }}
 }
 

--- a/man/biomod2.inner-methods.Rd
+++ b/man/biomod2.inner-methods.Rd
@@ -41,7 +41,7 @@ biomod2 internal functions.
 
 
 \details{
-  All this functions are low level functions. Interested people can go into source code for futher details.
+  All this functions are low level functions. Interested people can go into source code for further details.
 }
 
 

--- a/man/evaluate.Rd
+++ b/man/evaluate.Rd
@@ -20,7 +20,7 @@ evaluate(model, data, stat, as.array=FALSE)
 }
 
 \details{
-Given model predictive score is evaluated on the new data set. It is done comparing binary transformed model predictions (on data set) to species occurrences (first column of \code{data} arg). A list of available evaluation metrics is given in \code{\link[biomod2]{BIOMOD_Modeling}} help file. For metrics that compared binary/binary data, a set of threshold will be test to transform continuous model prediction within binary ones. The return scores are the ones obtained for the threshold optimising tested metric (best score).
+Given model predictive score is evaluated on the new data set. It is done comparing binary transformed model predictions (on data set) to species occurrences (first column of \code{data} arg). A list of available evaluation metrics is given in \code{\link[biomod2]{BIOMOD_Modeling}} help file. For metrics that compared binary/binary data, a set of threshold will be test to transform continuous model prediction within binary ones. The return scores are the ones obtained for the threshold optimizing tested metric (best score).
 }
 
 \value{

--- a/man/full_shuffling.Rd
+++ b/man/full_shuffling.Rd
@@ -6,7 +6,7 @@
 %%  ~~function to do ... ~~
 }
 \description{
-  This function is developper tool to shuffle elegantly data-set. This function shuffle one column of a given data.set
+  This function is developer tool to shuffle elegantly data-set. This function shuffle one column of a given data.set
 %%  ~~ A concise (1-5 lines) description of what the function does. ~~
 }
 

--- a/man/full_shuffling.Rd
+++ b/man/full_shuffling.Rd
@@ -6,7 +6,7 @@
 %%  ~~function to do ... ~~
 }
 \description{
-  This function is developper tool to shuffle elegantly data-set. This function suffle one column of a given data.set
+  This function is developper tool to shuffle elegantly data-set. This function shuffle one column of a given data.set
 %%  ~~ A concise (1-5 lines) description of what the function does. ~~
 }
 
@@ -15,13 +15,13 @@ full_suffling(x,id=NULL)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
-  \item{x}{ a \code{data.frame} you want to suffle}
-  \item{id}{ the columms you want to shuffle}
+  \item{x}{ a \code{data.frame} you want to shuffle}
+  \item{id}{ the columns you want to shuffle}
 }
 
 
 \value{
-  a \code{data.frame} with selected columns suffled compared to the original table.
+  a \code{data.frame} with selected columns shuffled compared to the original table.
 }
 
 \author{
@@ -41,6 +41,6 @@ full_suffling(xx,c(1,2))
 }
 % Add one or more standard keywords, see file 'KEYWORDS' in the
 % R documentation directory.
-\keyword{ suffle }
+\keyword{ shuffle }
 \keyword{ random }
 \keyword{ importance }% __ONLY ONE__ keyword per line

--- a/man/level.plot.Rd
+++ b/man/level.plot.Rd
@@ -26,7 +26,7 @@ level.plot( data.in,
   \item{XY}{ a 2 columns matrix of the same length as data.in giving the coordinates of the data points}
   \item{color.gradient}{ available : red, grey and blue }
   \item{cex}{ to change the point size : >1 will increase size, <1 will decrease it }
-  \item{level.range}{ the range of values for which you want the color gradient to be used, usefull to increase the resolution
+  \item{level.range}{ the range of values for which you want the color gradient to be used, useful to increase the resolution
   of the graph especially if you have extreme values (see examples section) }
   \item{show.scale}{ a feature for just keeping the graph without the scale (if set to False) }
   \item{title}{ the title wanted for the graph }

--- a/man/makeFormula.Rd
+++ b/man/makeFormula.Rd
@@ -30,7 +30,7 @@ It's advise to give only a subset of \code{explVar} table to avoid useless memor
 
 \code{...} argument available values are :
 \itemize{
-  \item{k}{ the smooting parameter value (used only if \code{type = 's_smoother'}) corresponding to \code{k} parameter of \pkg{mgcv} \code{\link[mgcv]{s}}} or \code{df} \pkg{gam} \code{\link[gam]{s}} arguments.
+  \item{k}{ the smoothing parameter value (used only if \code{type = 's_smoother'}) corresponding to \code{k} parameter of \pkg{mgcv} \code{\link[mgcv]{s}}} or \code{df} \pkg{gam} \code{\link[gam]{s}} arguments.
 
 }
 }

--- a/man/makeFormula.Rd
+++ b/man/makeFormula.Rd
@@ -7,9 +7,9 @@
 }
 
 \usage{
-makeFormula(respName, 
-            explVar, 
-            type = 'simple', 
+makeFormula(respName,
+            explVar,
+            type = 'simple',
             interaction.level = 0,
             ...)
 }
@@ -28,16 +28,16 @@ makeFormula(respName,
 \details{
 It's advise to give only a subset of \code{explVar} table to avoid useless memory consuming. If some explanatory variables are factorial ones, you have to give a \code{data.frame} for \code{explVar} where associated columns are define as \code{factor}.
 
-\code{...} argument availables values are :
+\code{...} argument available values are :
 \itemize{
-  \item{k}{ the smooting parameter value (used only if \code{type = 's_smoother'}) corespunding to \code{k} parameter of \pkg{mgcv} \code{\link[mgcv]{s}}} or \code{df} \pkg{gam} \code{\link[gam]{s}} arguments.
+  \item{k}{ the smooting parameter value (used only if \code{type = 's_smoother'}) corresponding to \code{k} parameter of \pkg{mgcv} \code{\link[mgcv]{s}}} or \code{df} \pkg{gam} \code{\link[gam]{s}} arguments.
 
 }
 }
 
 
 \value{
-A \code{link[stats]{formula}} class object that can be directly given to most of \R statistical models.   
+A \code{link[stats]{formula}} class object that can be directly given to most of \R statistical models.
 }
 
 
@@ -51,9 +51,9 @@ myResp <- sample(c(0,1),20, replace=TRUE)
 myExpl <- matrix(runif(60), ncol=3, dimnames=list(NULL,c('var1','var2','var3')))
 
 # create a formula
-myFormula <- makeFormula( respName = 'myResp', 
-                          explVar = head(myExpl), 
-                          type = 'quadratic', 
+myFormula <- makeFormula( respName = 'myResp',
+                          explVar = head(myExpl),
+                          type = 'quadratic',
                           interaction.level = 0)
 # show formula created
 myFormula

--- a/man/response.plot.Rd
+++ b/man/response.plot.Rd
@@ -17,7 +17,7 @@ response.plot(model,
 
 \arguments{
   \item{model}{ the model for which you want the response curves to be plotted. Compatible with GAM, GBM, GLM, ANN, CTA, RF, FDA and MARS.}
-  \item{Data}{ the variables for which you want the response curves to be plotted. A data frame is wanted with one column per vriable. They have to have the same names 
+  \item{Data}{ the variables for which you want the response curves to be plotted. A data frame is wanted with one column per variable. They have to have the same names 
    as the ones used to calibrate the model.}
   \item{show.variables}{ give in the column numbers of 'Data' for selecting the variables that are wanted for plotting }
   \item{save.file}{ can be set to "pdf", "jpeg" or "tiff" to save the plot. Pdf options can be changed by setting the default values of pdf.options().}

--- a/man/response.plot2.Rd
+++ b/man/response.plot2.Rd
@@ -31,10 +31,10 @@ response.plot2( models,
   \item{plot}{ if TRUE (the default) then a plot is produced}
   \item{\ldots}{ further arguments :
     \itemize{
-      \item{\code{data_species} : vector containing data species occurances. Have to match with \code{Data}. If given, the statistic used to fix variables value will be calculated only over presences points. (Considered only if \code{Data} is under table format)}
+      \item{\code{data_species} : vector containing data species occurrences. Have to match with \code{Data}. If given, the statistic used to fix variables value will be calculated only over presences points. (Considered only if \code{Data} is under table format)}
       \item{\code{col} : vector of colors to be used (only for univariate case)}
       \item{\code{lty} : vector of lines types to be used}
-      \item{\code{main} : character, the title of the graph (default one based on first model class is automatically produced if not refered)}
+      \item{\code{main} : character, the title of the graph (default one based on first model class is automatically produced if not referred)}
       \item{\code{display_title} : logical, display or not graph title}
       \item{\code{legend} : logical, add legend to plot (only for univariate case)}
     }}

--- a/man/sample.factor.levels.Rd
+++ b/man/sample.factor.levels.Rd
@@ -15,7 +15,7 @@ been sampled. The factor levels within this mask will not be sampled.}
 \item{mask.in}{a Raster/list of Raster/data.frame mask (potentially a stack of 
 masks) indicating areas were we want to sample our factor level in priority.
 Note that if after having explore this masks some levels of the considered
-factorial varialble remains unsampled, this levels will be sampled in the 
+factorial variable remains unsampled, this levels will be sampled in the 
 reference input object (here 'x')}
 }
 \value{
@@ -32,12 +32,12 @@ In case any factorial variable is found in the input object then
   NULL is returned.
 }
 \note{
-- The x/mask.out/mask.in should be coherent in term of dimention (same number of 
-    rows for data.frame and same number of rows, column, identic resolution 
+- The x/mask.out/mask.in should be coherent in term of dimension (same number of 
+    rows for data.frame and same number of rows, column, identical resolution 
     and projection coordinates system for Raster* objects)
   - If mask.in contains several masks (RasterStack or multi-column data.frame)
     then the order of the mask matter. The mask will be considered successively.
-    The first will be use prioritarly to sample our variable factor levels and 
+    The first will be use prioritarily to sample our variable factor levels and 
     so on.
   - Raster* masks will be understood as: 
       - NA: out of of mask

--- a/man/sre.Rd
+++ b/man/sre.Rd
@@ -20,7 +20,7 @@ sre(Response = NULL,
   \item{NewData}{ The data for which you want to render predictions with the sre. It must be a matrix (resp. a data.frame, a SpatialPointsDataFrame or a RasterStack ) of the same type as the one given in Explanatory and with precisely the same variable names. }
   \item{Quant}{ the value defines the most extreme values for each variable not to be taken into account
    for determining the tolerance boundaries for the considered species.  }
-   \item{return_extremcond}{ boolean, if TRUE a matrix containing extrem conditions supported is returned}
+   \item{return_extremcond}{ boolean, if TRUE a matrix containing extreme conditions supported is returned}
 }
 \details{
 

--- a/man/update_objects.Rd
+++ b/man/update_objects.Rd
@@ -17,7 +17,7 @@
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{obj}{ a \code{biomod2} object you want to update (e.g. 'BIOMOD.formated.data', 'biomod2_model' object)}
-  \item{recursive}{ logical, if TRUE all objects on which updated object is based will be also updtaed }
+  \item{recursive}{ logical, if TRUE all objects on which updated object is based will be also updated }
 }
 
 \details{


### PR DESCRIPTION
Hey biomod2 developers,
I corrected a couple of typos and misspellings in the documentation of `biomod2` using `devtools::spell_check()`  function.
I plan to correct a couple more typos in errors messages and warnings ;)
Tell me if it works for you ;)
Matthias