### PR TITLE
Fix bug preventing execution of `bm_PlotResponseCurves`

### DIFF
--- a/R/bm_PlotResponseCurves.R
+++ b/R/bm_PlotResponseCurves.R
@@ -322,11 +322,9 @@ bm_PlotResponseCurves <- function(bm.out
   
   ## 2. PLOT graphic ------------------------------------------------------------------------------
   if (!do.bivariate) {
-    new.env_m <- melt(new.env[, show.variables], variable.name = "expl.name", value.name = "expl.val")
-    
     gg <- ggplot(ggdat, aes_string(x = "expl.val", y = "pred.val", color = "pred.name")) +
       geom_line() +
-      geom_rug(data = new.env_m, sides = 'b', inherit.aes = FALSE, aes_string(x = "expl.val")) +
+      geom_rug(sides = 'b') +
       facet_wrap("expl.name", scales = "free_x") +
       xlab("") +
       ylab("") +


### PR DESCRIPTION
In some cases, the `melt` function on line 325 fails to generate the expected `data.frame`, meaning that the plot doesn't render. Simplest approach is to remove and plot the raw data instead; though it's possible there is a better answer to this! Thanks for your work, the new release looks great :)