### PR TITLE
get_predictions bugfix

### DIFF
--- a/R/biomod2_classes_3.R
+++ b/R/biomod2_classes_3.R
@@ -1037,7 +1037,7 @@ setMethod("get_predictions", "BIOMOD.projection.out",
             out <- load_stored_object(obj@proj.out, layer = selected.layers)
             
             # subselection of models_selected
-            if (obj@type == "SpatRaster") {
+            if (any(obj@type == "SpatRaster")) {
               if (length(grep("EM|merged", names(out))) > 0) {
                 keep_layers <- .filter_outputs.vec(names(out), obj.type = "em", 
                                                    subset.list = list(full.name =  full.name


### PR DESCRIPTION
Proposed fix to issue https://github.com/biomodhub/biomod2/issues/209.

Another option would be to reverse the `if` such that:
```
if (all(obj@type != "SpatRaster")) {}
```
But that would involve a bigger code change, which I hesitate in proposing.