### PR TITLE
Fix typos following 'spelling::spell_check_package()'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Description: Functions for species distribution modeling, calibration and evalua
   ensemble of models, ensemble forecasting and visualization. The package permits to run
   consistently up to 10 single models on a presence/absences (resp presences/pseudo-absences)
   dataset and to combine them in ensemble models and ensemble projections. Some bench of other 
-  evaluation and visualisation tools are also available within the package.
+  evaluation and visualization tools are also available within the package.
 Depends:
     R (>= 4.1)
 Imports:

--- a/R/BIOMOD_Modeling.R
+++ b/R/BIOMOD_Modeling.R
@@ -215,7 +215,7 @@
 ##'     \item{presence-only}{
 ##'     \itemize{
 ##'       \item \code{BOYCE} : Boyce index
-##'       \item \code{MPA} : Minimal predicted area (cutoff optimising MPA to predict 90\% of 
+##'       \item \code{MPA} : Minimal predicted area (cutoff optimizing MPA to predict 90\% of 
 ##'       presences)
 ##'     }
 ##'     }
@@ -232,7 +232,7 @@
 ##'   \code{eval.[...]} parameters in \code{\link{BIOMOD_FormatingData}}.}
 ##'   }
 ##'   
-##'   \item{var.import}{A value caracterizing how much each variable has an impact on each model 
+##'   \item{var.import}{A value characterizing how much each variable has an impact on each model 
 ##'   predictions can be calculated by randomizing the variable of interest and computing the 
 ##'   correlation between original and shuffled variables (see \code{\link{bm_VariablesImportance}}).}
 ##'   

--- a/R/biomod2_classes_3.R
+++ b/R/biomod2_classes_3.R
@@ -668,7 +668,7 @@ setMethod("get_variables_importance", "BIOMOD.models.out",
 ##'   determining whether x and y scales are shared among facet. Argument passed
 ##'   to \code{\link[ggplot2:facet_wrap]{facet_wrap}}. Possible values: 'fixed', 'free_x',
 ##'   'free_y', 'free'.
-##' @param size (\emph{optional, default} \code{0.75}) a numeric determing the
+##' @param size (\emph{optional, default} \code{0.75}) a numeric determining the
 ##'   size of points on the plots and passed to
 ##'   \code{\link[ggplot2:geom_point]{geom_point}}.
 ##' @param ... additional parameters to be passed to \code{\link{get_predictions}} 

--- a/R/biomod2_data.R
+++ b/R/biomod2_data.R
@@ -240,7 +240,7 @@
 #'   \item{ConnochaetesGnou}{Presence (1) or Absence (0) for black wildebeest}
 #'   \item{GuloGulo}{Presence (1) or Absence (0) for wolverine}
 #'   \item{PantheraOnca}{Presence (1) or Absence (0) for jaguar}
-#'   \item{PteropusGiganteus}{Presence (1) or Absence (0) for indian flying fox}
+#'   \item{PteropusGiganteus}{Presence (1) or Absence (0) for Indian flying fox}
 #'   \item{TenrecEcaudatus}{Presence (1) or Absence (0) for tailless tenrec}
 #'   \item{VulpesVulpes}{Presence (1) or Absence (0) for red fox}
 #' }

--- a/R/bm_BinaryTransformation.R
+++ b/R/bm_BinaryTransformation.R
@@ -45,7 +45,7 @@
 ##' @keywords convert threshold binary filter
 ##' 
 ##' @seealso \code{\link{BIOMOD_Projection}}, \code{\link{BIOMOD_EnsembleForecasting}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##'
 ##' 
 ##' @examples

--- a/R/bm_CrossValidation.R
+++ b/R/bm_CrossValidation.R
@@ -138,7 +138,7 @@
 ##' 
 ##' @seealso \code{\link[ENMeval]{get.block}}, \code{\link[dismo]{kfold}}, 
 ##' \code{\link{BIOMOD_FormatingData}}, \code{\link{BIOMOD_Modeling}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##'
 ##'
 ##' @examples

--- a/R/bm_FindOptimStat.R
+++ b/R/bm_FindOptimStat.R
@@ -77,7 +77,7 @@
 ##'   \item{presence-only}{
 ##'   \itemize{
 ##'     \item \code{BOYCE} : Boyce index
-##'     \item \code{MPA} : Minimal predicted area (cutoff optimising MPA to predict 90\% of 
+##'     \item \code{MPA} : Minimal predicted area (cutoff optimizing MPA to predict 90\% of 
 ##'     presences)
 ##'   }
 ##'   }
@@ -87,7 +87,7 @@
 ##' \emph{Please refer to the \href{https://www.cawcr.gov.au/projects/verification/}{CAWRC website 
 ##' (section "Methods for dichotomous forecasts")} to get detailed description of each metric.}
 ##' 
-##' Note that if a value is given to \code{threshold}, no optimisation will be done., and 
+##' Note that if a value is given to \code{threshold}, no optimization will be done., and 
 ##' only the score for this threshold will be returned.
 ##' 
 ##' The Boyce index returns \code{NA} values for \code{SRE} models because it can not be 
@@ -117,7 +117,7 @@
 ##' @seealso \code{ecospat.boyce()} and \code{ecospat.mpa()} in \pkg{ecospat}, 
 ##' \code{\link{BIOMOD_Modeling}}, \code{\link{bm_RunModelsLoop}}, 
 ##' \code{\link{BIOMOD_EnsembleModeling}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' 
 ##' 
 ##' @examples

--- a/R/bm_MakeFormula.R
+++ b/R/bm_MakeFormula.R
@@ -38,7 +38,7 @@
 ##' @seealso \code{\link[stats]{formula}}, \code{\link[mgcv]{s}}, \code{\link[gam]{s}}, 
 ##' \code{\link{bm_ModelingOptions}}, \code{\link{bm_Tuning}}, 
 ##' \code{\link{bm_RunModelsLoop}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' 
 ##' 
 ##' @examples

--- a/R/bm_ModelingOptions.R
+++ b/R/bm_ModelingOptions.R
@@ -133,7 +133,7 @@
 ##' 
 ##' @seealso \code{\link{ModelsTable}}, \code{\link{BIOMOD.models.options}}, 
 ##' \code{\link{bm_Tuning}}, \code{\link{BIOMOD_Modeling}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' 
 ##' 
 ##' @examples

--- a/R/bm_PlotEvalBoxplot.R
+++ b/R/bm_PlotEvalBoxplot.R
@@ -51,7 +51,7 @@
 ##' @seealso \code{\link{BIOMOD.models.out}}, \code{\link{BIOMOD.ensemble.models.out}}, 
 ##' \code{\link{BIOMOD_Modeling}}, \code{\link{BIOMOD_EnsembleModeling}}, 
 ##' \code{\link{get_evaluations}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' @family Plot functions
 ##' 
 ##' 

--- a/R/bm_PlotEvalMean.R
+++ b/R/bm_PlotEvalMean.R
@@ -57,7 +57,7 @@
 ##' @seealso \code{\link{BIOMOD.models.out}}, \code{\link{BIOMOD.ensemble.models.out}}, 
 ##' \code{\link{BIOMOD_Modeling}}, \code{\link{BIOMOD_EnsembleModeling}}, 
 ##' \code{\link{get_evaluations}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' @family Plot functions
 ##' 
 ##' 

--- a/R/bm_PlotRangeSize.R
+++ b/R/bm_PlotRangeSize.R
@@ -52,7 +52,7 @@
 ##' 
 ##' 
 ##' @seealso \code{\link{BIOMOD_RangeSize}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' @family Plot functions
 ##' 
 ##' 

--- a/R/bm_PlotResponseCurves.R
+++ b/R/bm_PlotResponseCurves.R
@@ -85,7 +85,7 @@
 ##' 
 ##' @seealso \code{\link{BIOMOD.models.out}}, \code{\link{BIOMOD.ensemble.models.out}}, 
 ##' \code{\link{BIOMOD_Modeling}}, \code{\link{BIOMOD_EnsembleModeling}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' @family Plot functions
 ##' 
 ##' 

--- a/R/bm_PlotVarImpBoxplot.R
+++ b/R/bm_PlotVarImpBoxplot.R
@@ -46,7 +46,7 @@
 ##' @seealso \code{\link{BIOMOD.models.out}}, \code{\link{BIOMOD.ensemble.models.out}}, 
 ##' \code{\link{BIOMOD_Modeling}}, \code{\link{BIOMOD_EnsembleModeling}}, 
 ##' \code{\link{get_variables_importance}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' @family Plot functions
 ##' 
 ##' 

--- a/R/bm_PseudoAbsences.R
+++ b/R/bm_PseudoAbsences.R
@@ -99,7 +99,7 @@
 ##' 
 ##' @seealso \code{\link{bm_SRE}}, \code{\link{BIOMOD.formated.data.PA}}, 
 ##' \code{\link{BIOMOD_FormatingData}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' 
 ##' 
 ##' @examples 

--- a/R/bm_RunModelsLoop.R
+++ b/R/bm_RunModelsLoop.R
@@ -91,7 +91,7 @@
 ##' \code{\link{bm_ModelingOptions}}, \code{\link{BIOMOD_Modeling}}, 
 ##' \code{\link{bm_MakeFormula}}, \code{\link{bm_SampleFactorLevels}}, 
 ##' \code{\link{bm_FindOptimStat}}, \code{\link{bm_VariablesImportance}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' 
 ##' 
 ##' @importFrom foreach foreach %do% %dopar% 

--- a/R/bm_SRE.R
+++ b/R/bm_SRE.R
@@ -51,7 +51,7 @@
 ##' can discriminate the extreme values from the main tendency, the SRE considers them as 
 ##' important as any other data point leading to changes in predictions. \cr \cr
 ##' 
-##' \emph{The more (non-colinear) variables, the more restrictive the model will be.} \cr \cr
+##' \emph{The more (non-collinear) variables, the more restrictive the model will be.} \cr \cr
 ##' 
 ##' Predictions are returned as binary (\code{0} or \code{1}) values, a site being either 
 ##' potentially suitable for all the variables, or out of bounds for at least one variable and 
@@ -80,7 +80,7 @@
 ##' @seealso \code{\link{bm_PseudoAbsences}}, \code{\link{BIOMOD_FormatingData}}, 
 ##' \code{\link{bm_ModelingOptions}}, \code{\link{bm_Tuning}}, 
 ##' \code{\link{bm_RunModelsLoop}}, \code{\link{BIOMOD_Modeling}},
-##' @family Secundary functions
+##' @family Secondary functions
 ##' 
 ##' @examples
 ##' 

--- a/R/bm_SampleBinaryVector.R
+++ b/R/bm_SampleBinaryVector.R
@@ -31,7 +31,7 @@
 ##'   
 ##' @keywords sample binary
 ##' 
-##' @family Secundary functions
+##' @family Secondary functions
 ##' 
 ##' 
 ##' @examples

--- a/R/bm_SampleFactorLevels.R
+++ b/R/bm_SampleFactorLevels.R
@@ -25,7 +25,7 @@
 ##' @return  
 ##' 
 ##' A \code{vector} of \code{numeric} values corresponding to either row (\code{data.frame}) or 
-##' cell (\code{\link[terra:rast]{SpatRaster}}) numbers, each refering to a single level of a 
+##' cell (\code{\link[terra:rast]{SpatRaster}}) numbers, each referring to a single level of a 
 ##' single factorial variable.
 ##' 
 ##' In case no factorial variable is found in the input object, \code{NULL} is returned.
@@ -62,7 +62,7 @@
 ##' @keywords sample factor
 ##' 
 ##' @seealso \code{\link{bm_PseudoAbsences}}, \code{\link{bm_CrossValidation}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' 
 ##'   
 ##' @examples

--- a/R/bm_Tuning.R
+++ b/R/bm_Tuning.R
@@ -109,7 +109,7 @@
 ##' \code{\link[ENMeval]{ENMevaluate}}, 
 ##' \code{\link{ModelsTable}}, \code{\link{BIOMOD.models.options}}, 
 ##' \code{\link{bm_ModelingOptions}}, \code{\link{BIOMOD_Modeling}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' 
 ##' 
 ##' @examples

--- a/R/bm_VariablesImportance.R
+++ b/R/bm_VariablesImportance.R
@@ -15,7 +15,7 @@
 ##' compute the variables importance
 ##' @param variables (\emph{optional, default} \code{NULL}) \cr 
 ##' A \code{vector} containing the names of the explanatory variables that will be considered
-##' @param method a \code{character} corresponding to the randomisation method to be used, must be 
+##' @param method a \code{character} corresponding to the randomization method to be used, must be 
 ##' \code{full_rand} (\emph{only method available so far})
 ##' @param nb.rep an \code{integer} corresponding to the number of permutations to be done for 
 ##' each variable
@@ -66,7 +66,7 @@
 ##' \code{\link{bm_RunModelsLoop}}, \code{\link{BIOMOD_Modeling}}, 
 ##' \code{\link{BIOMOD_EnsembleModeling}}, \code{\link{bm_PlotVarImpBoxplot}}, 
 ##' \code{\link{get_variables_importance}}
-##' @family Secundary functions
+##' @family Secondary functions
 ##' 
 ##' 
 ##' @examples

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ devtools::install_github("biomodhub/biomod2", dependencies = TRUE)
 
 - modeling options are now automatically retrieved from single models functions, normally allowing the use of all arguments taken into account by these functions
 - tuning has been cleaned up, but keep in mind that it is still a quite long running process
-- in consequence, `BIOMOD_ModelingOptions` and `BIOMOD_Tuning` functions become secundary functions (`bm_ModelingOptions` and `bm_Tuning`), and modeling options can be directly built through `BIOMOD_Modeling` function
+- in consequence, `BIOMOD_ModelingOptions` and `BIOMOD_Tuning` functions become secondary functions (`bm_ModelingOptions` and `bm_Tuning`), and modeling options can be directly built through `BIOMOD_Modeling` function
 
 #### <i class="fas fa-plus-square"></i> What is new ?
 
@@ -102,7 +102,7 @@ devtools::install_github("biomodhub/biomod2", dependencies = TRUE)
 - 3 new vignettes have been created :
     - [data preparation](https://biomodhub.github.io/biomod2/articles/vignette_dataPreparation.html) (*questions you should ask yourself before modeling*)
     - [cross-validation](https://biomodhub.github.io/biomod2/articles/vignette_crossValidation.html) (*to prepare your own calibration / validation datasets*)
-    - [modeling options](https://biomodhub.github.io/biomod2/articles/vignette_dataPreparation.html) (*to help you navigate through the new way of parameterizing single models*)
+    - [modeling options](https://biomodhub.github.io/biomod2/articles/vignette_dataPreparation.html) (*to help you navigate through the new way of parametrizing single models*)
 
 <br/>
 
@@ -127,7 +127,7 @@ Sorry for the inconvenience, and please **feel free to indicate if you notice so
 #### <i class="fas fa-exchange-alt"></i> What is changed ?
 
 - all code functions have been cleaned, and old / unused functions have been removed
-- function names have been standardized (`BIOMOD_` for main functions, `bm_` for secundary functions)
+- function names have been standardized (`BIOMOD_` for main functions, `bm_` for secondary functions)
 - parameter names have been standardized (same typo, same names for similar parameters across functions)
 - all documentation and examples have been cleaned up
 

--- a/man/BIOMOD.projection.out.Rd
+++ b/man/BIOMOD.projection.out.Rd
@@ -46,7 +46,7 @@ determining whether x and y scales are shared among facet. Argument passed
 to \code{\link[ggplot2:facet_wrap]{facet_wrap}}. Possible values: 'fixed', 'free_x',
 'free_y', 'free'.}
 
-\item{size}{(\emph{optional, default} \code{0.75}) a numeric determing the
+\item{size}{(\emph{optional, default} \code{0.75}) a numeric determining the
 size of points on the plots and passed to
 \code{\link[ggplot2:geom_point]{geom_point}}.}
 

--- a/man/BIOMOD_Modeling.Rd
+++ b/man/BIOMOD_Modeling.Rd
@@ -274,7 +274,7 @@ metrics (see Details).
     \item{presence-only}{
     \itemize{
       \item \code{BOYCE} : Boyce index
-      \item \code{MPA} : Minimal predicted area (cutoff optimising MPA to predict 90\% of 
+      \item \code{MPA} : Minimal predicted area (cutoff optimizing MPA to predict 90\% of 
       presences)
     }
     }
@@ -291,7 +291,7 @@ metrics (see Details).
   \code{eval.[...]} parameters in \code{\link{BIOMOD_FormatingData}}.}
   }
   
-  \item{var.import}{A value caracterizing how much each variable has an impact on each model 
+  \item{var.import}{A value characterizing how much each variable has an impact on each model 
   predictions can be calculated by randomizing the variable of interest and computing the 
   correlation between original and shuffled variables (see \code{\link{bm_VariablesImportance}}).}
   

--- a/man/DataSpecies.Rd
+++ b/man/DataSpecies.Rd
@@ -12,7 +12,7 @@ A \code{data.frame} object with 2488 rows and 10 variables:
   \item{ConnochaetesGnou}{Presence (1) or Absence (0) for black wildebeest}
   \item{GuloGulo}{Presence (1) or Absence (0) for wolverine}
   \item{PantheraOnca}{Presence (1) or Absence (0) for jaguar}
-  \item{PteropusGiganteus}{Presence (1) or Absence (0) for indian flying fox}
+  \item{PteropusGiganteus}{Presence (1) or Absence (0) for Indian flying fox}
   \item{TenrecEcaudatus}{Presence (1) or Absence (0) for tailless tenrec}
   \item{VulpesVulpes}{Presence (1) or Absence (0) for red fox}
 }

--- a/man/bm_BinaryTransformation.Rd
+++ b/man/bm_BinaryTransformation.Rd
@@ -72,7 +72,7 @@ cbind(vec.d, vec.d_bin, vec.d_filt)
 \seealso{
 \code{\link{BIOMOD_Projection}}, \code{\link{BIOMOD_EnsembleForecasting}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
 \code{\link{bm_MakeFormula}()},
@@ -93,7 +93,7 @@ Other Secundary functions:
 \author{
 Wilfried Thuiller, Damien Georges
 }
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{binary}
 \keyword{convert}
 \keyword{filter}

--- a/man/bm_CrossValidation.Rd
+++ b/man/bm_CrossValidation.Rd
@@ -286,7 +286,7 @@ apply(cv.e, 2, table)
 \code{\link[ENMeval]{get.block}}, \code{\link[dismo]{kfold}}, 
 \code{\link{BIOMOD_FormatingData}}, \code{\link{BIOMOD_Modeling}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_FindOptimStat}()},
 \code{\link{bm_MakeFormula}()},
@@ -307,4 +307,4 @@ Other Secundary functions:
 \author{
 Frank Breiner, Maya Gueguen
 }
-\concept{Secundary functions}
+\concept{Secondary functions}

--- a/man/bm_FindOptimStat.Rd
+++ b/man/bm_FindOptimStat.Rd
@@ -94,7 +94,7 @@ metric.
   \item{presence-only}{
   \itemize{
     \item \code{BOYCE} : Boyce index
-    \item \code{MPA} : Minimal predicted area (cutoff optimising MPA to predict 90\% of 
+    \item \code{MPA} : Minimal predicted area (cutoff optimizing MPA to predict 90\% of 
     presences)
   }
   }
@@ -153,7 +153,7 @@ bm_FindOptimStat(metric.eval = 'TSS', fit = vec.c, obs = vec.a, threshold = 280)
 \code{\link{BIOMOD_Modeling}}, \code{\link{bm_RunModelsLoop}}, 
 \code{\link{BIOMOD_EnsembleModeling}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_MakeFormula}()},
@@ -174,7 +174,7 @@ Other Secundary functions:
 \author{
 Damien Georges
 }
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{auc}
 \keyword{boyce}
 \keyword{evaluation}

--- a/man/bm_MakeFormula.Rd
+++ b/man/bm_MakeFormula.Rd
@@ -62,7 +62,7 @@ bm_MakeFormula(resp.name = 'myResp.s',
 \code{\link{bm_ModelingOptions}}, \code{\link{bm_Tuning}}, 
 \code{\link{bm_RunModelsLoop}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -83,7 +83,7 @@ Other Secundary functions:
 \author{
 Damien Georges
 }
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{formula}
 \keyword{models}
 \keyword{options}

--- a/man/bm_ModelingOptions.Rd
+++ b/man/bm_ModelingOptions.Rd
@@ -241,7 +241,7 @@ opt.t
 \code{\link{ModelsTable}}, \code{\link{BIOMOD.models.options}}, 
 \code{\link{bm_Tuning}}, \code{\link{BIOMOD_Modeling}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -262,6 +262,6 @@ Other Secundary functions:
 \author{
 Damien Georges, Wilfried Thuiller, Maya Gueguen
 }
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{models}
 \keyword{options}

--- a/man/bm_PlotEvalBoxplot.Rd
+++ b/man/bm_PlotEvalBoxplot.Rd
@@ -118,7 +118,7 @@ bm_PlotEvalBoxplot(bm.out = myBiomodModelOut, group.by = c('algo', 'run'))
 \code{\link{BIOMOD_Modeling}}, \code{\link{BIOMOD_EnsembleModeling}}, 
 \code{\link{get_evaluations}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -146,7 +146,7 @@ Other Plot functions:
 Damien Georges, Maya Gueguen
 }
 \concept{Plot functions}
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{boxplot}
 \keyword{evaluation}
 \keyword{ggplot}

--- a/man/bm_PlotEvalMean.Rd
+++ b/man/bm_PlotEvalMean.Rd
@@ -126,7 +126,7 @@ bm_PlotEvalMean(bm.out = myBiomodModelOut)
 \code{\link{BIOMOD_Modeling}}, \code{\link{BIOMOD_EnsembleModeling}}, 
 \code{\link{get_evaluations}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -154,6 +154,6 @@ Other Plot functions:
 Damien Georges, Maya Gueguen
 }
 \concept{Plot functions}
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{evaluation}
 \keyword{ggplot}

--- a/man/bm_PlotRangeSize.Rd
+++ b/man/bm_PlotRangeSize.Rd
@@ -160,7 +160,7 @@ bm_PlotRangeSize(bm.range = myBiomodRangeSize)
 \seealso{
 \code{\link{BIOMOD_RangeSize}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -188,7 +188,7 @@ Other Plot functions:
 Maya Gueguen
 }
 \concept{Plot functions}
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{"species}
 \keyword{change"}
 \keyword{gain}

--- a/man/bm_PlotResponseCurves.Rd
+++ b/man/bm_PlotResponseCurves.Rd
@@ -171,7 +171,7 @@ bm_PlotResponseCurves(bm.out = myBiomodModelOut,
 \code{\link{BIOMOD.models.out}}, \code{\link{BIOMOD.ensemble.models.out}}, 
 \code{\link{BIOMOD_Modeling}}, \code{\link{BIOMOD_EnsembleModeling}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -199,7 +199,7 @@ Other Plot functions:
 Damien Georges, Maya Gueguen
 }
 \concept{Plot functions}
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{curve}
 \keyword{ggplot}
 \keyword{response}

--- a/man/bm_PlotVarImpBoxplot.Rd
+++ b/man/bm_PlotVarImpBoxplot.Rd
@@ -112,7 +112,7 @@ bm_PlotVarImpBoxplot(bm.out = myBiomodModelOut, group.by = c('algo', 'expl.var',
 \code{\link{BIOMOD_Modeling}}, \code{\link{BIOMOD_EnsembleModeling}}, 
 \code{\link{get_variables_importance}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -140,7 +140,7 @@ Other Plot functions:
 Damien Georges, Maya Gueguen
 }
 \concept{Plot functions}
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{boxplot}
 \keyword{evaluation}
 \keyword{ggplot}

--- a/man/bm_PseudoAbsences.Rd
+++ b/man/bm_PseudoAbsences.Rd
@@ -257,7 +257,7 @@ apply(PA.r_mult$pa.tab, 2, table)
 \code{\link{bm_SRE}}, \code{\link{BIOMOD.formated.data.PA}}, 
 \code{\link{BIOMOD_FormatingData}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -278,7 +278,7 @@ Other Secundary functions:
 \author{
 Wilfried Thuiller, Damien Georges
 }
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{SRE}
 \keyword{disk}
 \keyword{pseudo-absence}

--- a/man/bm_RunModelsLoop.Rd
+++ b/man/bm_RunModelsLoop.Rd
@@ -136,7 +136,7 @@ species distribution models (asked by the \code{\link{BIOMOD_Modeling}} function
 \code{\link{bm_MakeFormula}}, \code{\link{bm_SampleFactorLevels}}, 
 \code{\link{bm_FindOptimStat}}, \code{\link{bm_VariablesImportance}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -157,7 +157,7 @@ Other Secundary functions:
 \author{
 Damien Georges
 }
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{ANN}
 \keyword{CTA}
 \keyword{FDA}

--- a/man/bm_SRE.Rd
+++ b/man/bm_SRE.Rd
@@ -122,7 +122,7 @@ plot(res)
 \code{\link{bm_ModelingOptions}}, \code{\link{bm_Tuning}}, 
 \code{\link{bm_RunModelsLoop}}, \code{\link{BIOMOD_Modeling}},
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -143,7 +143,7 @@ Other Secundary functions:
 \author{
 Wilfried Thuiller, Bruno Lafourcade, Damien Georges
 }
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{"surface}
 \keyword{envelop"}
 \keyword{models}

--- a/man/bm_SampleBinaryVector.Rd
+++ b/man/bm_SampleBinaryVector.Rd
@@ -42,7 +42,7 @@ bm_SampleBinaryVector(obs = vec.a, ratio = 0.7)
 
 }
 \seealso{
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -63,6 +63,6 @@ Other Secundary functions:
 \author{
 Damien Georges
 }
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{binary}
 \keyword{sample}

--- a/man/bm_SampleFactorLevels.Rd
+++ b/man/bm_SampleFactorLevels.Rd
@@ -23,7 +23,7 @@ remain unsampled, they will be sampled in the reference input object \code{expl.
 }
 \value{
 A \code{vector} of \code{numeric} values corresponding to either row (\code{data.frame}) or 
-cell (\code{\link[terra:rast]{SpatRaster}}) numbers, each refering to a single level of a 
+cell (\code{\link[terra:rast]{SpatRaster}}) numbers, each referring to a single level of a 
 single factorial variable.
 
 In case no factorial variable is found in the input object, \code{NULL} is returned.
@@ -88,7 +88,7 @@ samp3 <- bm_SampleFactorLevels(expl.var = stk, mask.out = mask.out, mask.in = ma
 \seealso{
 \code{\link{bm_PseudoAbsences}}, \code{\link{bm_CrossValidation}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -109,6 +109,6 @@ Other Secundary functions:
 \author{
 Damien Georges
 }
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{factor}
 \keyword{sample}

--- a/man/bm_Tuning.Rd
+++ b/man/bm_Tuning.Rd
@@ -214,7 +214,7 @@ tuned.gam
 \code{\link{ModelsTable}}, \code{\link{BIOMOD.models.options}}, 
 \code{\link{bm_ModelingOptions}}, \code{\link{BIOMOD_Modeling}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -235,4 +235,4 @@ Other Secundary functions:
 \author{
 Frank Breiner, Maya Gueguen, Helene Blancheteau
 }
-\concept{Secundary functions}
+\concept{Secondary functions}

--- a/man/bm_VariablesImportance.Rd
+++ b/man/bm_VariablesImportance.Rd
@@ -26,7 +26,7 @@ compute the variables importance}
 \item{variables}{(\emph{optional, default} \code{NULL}) \cr 
 A \code{vector} containing the names of the explanatory variables that will be considered}
 
-\item{method}{a \code{character} corresponding to the randomisation method to be used, must be 
+\item{method}{a \code{character} corresponding to the randomization method to be used, must be 
 \code{full_rand} (\emph{only method available so far})}
 
 \item{nb.rep}{an \code{integer} corresponding to the number of permutations to be done for 
@@ -93,7 +93,7 @@ bm_VariablesImportance(bm.model = mod,
 \code{\link{BIOMOD_EnsembleModeling}}, \code{\link{bm_PlotVarImpBoxplot}}, 
 \code{\link{get_variables_importance}}
 
-Other Secundary functions: 
+Other Secondary functions: 
 \code{\link{bm_BinaryTransformation}()},
 \code{\link{bm_CrossValidation}()},
 \code{\link{bm_FindOptimStat}()},
@@ -114,7 +114,7 @@ Other Secundary functions:
 \author{
 Damien Georges
 }
-\concept{Secundary functions}
+\concept{Secondary functions}
 \keyword{"Pearson}
 \keyword{correlation"}
 \keyword{importance}

--- a/vignettes/examples_1_mainFunctions.Rmd
+++ b/vignettes/examples_1_mainFunctions.Rmd
@@ -62,7 +62,7 @@ plot(myBiomodData)
 
 #### <i class="fa-solid fa-shuffle"></i> Pseudo-absences extraction
 
-Single or multiple set of pseudo-absences can be selected with the [`BIOMOD_FormatingData`](../reference/BIOMOD_FormatingData.html) function, which calls the [`bm_PseudoAbsences`](../reference/bm_PseudoAbsences.html) function to do so. More examples are presented on the [Secundary functions webpage](examples_2_secundaryFunctions.html).
+Single or multiple set of pseudo-absences can be selected with the [`BIOMOD_FormatingData`](../reference/BIOMOD_FormatingData.html) function, which calls the [`bm_PseudoAbsences`](../reference/bm_PseudoAbsences.html) function to do so. More examples are presented on the [Secondary functions webpage](examples_2_secundaryFunctions.html).
 
 ```R
 # # Transform true absences into potential pseudo-absences
@@ -102,7 +102,7 @@ Single or multiple set of pseudo-absences can be selected with the [`BIOMOD_Form
 
 #### <i class="fa-solid fa-scissors"></i> Cross-validation datasets
 
-Several cross-validation methods are available and can be selected with the [`BIOMOD_Modeling`](../reference/BIOMOD_Modeling.html) function, which calls the [`bm_CrossValidation`](../reference/bm_CrossValidation.html) function to do so. More examples are presented on the [Secundary functions webpage](examples_2_secundaryFunctions.html).
+Several cross-validation methods are available and can be selected with the [`BIOMOD_Modeling`](../reference/BIOMOD_Modeling.html) function, which calls the [`bm_CrossValidation`](../reference/bm_CrossValidation.html) function to do so. More examples are presented on the [Secondary functions webpage](examples_2_secundaryFunctions.html).
 
 ```R
 # # k-fold selection
@@ -123,7 +123,7 @@ Several cross-validation methods are available and can be selected with the [`BI
 
 #### <i class="fa-solid fa-rectangle-list"></i> Retrieve modeling options
 
-Modeling options are automatically retrieved from selected models within the [`BIOMOD_Modeling`](../reference/BIOMOD_Modeling.html) function, which calls the [`bm_ModelingOptions`](../reference/bm_ModelingOptions.html) function to do so. Model parameters can also be automatically tuned to a specific dataset, by calling the [`bm_Tuning`](../reference/bm_Tuning.html) function, however it can be quite long. More examples are presented on the [Secundary functions webpage](examples_2_secundaryFunctions.html).
+Modeling options are automatically retrieved from selected models within the [`BIOMOD_Modeling`](../reference/BIOMOD_Modeling.html) function, which calls the [`bm_ModelingOptions`](../reference/bm_ModelingOptions.html) function to do so. Model parameters can also be automatically tuned to a specific dataset, by calling the [`bm_Tuning`](../reference/bm_Tuning.html) function, however it can be quite long. More examples are presented on the [Secondary functions webpage](examples_2_secundaryFunctions.html).
 
 ```R
 # # bigboss parameters
@@ -144,7 +144,7 @@ Modeling options are automatically retrieved from selected models within the [`B
 <br/><br/>
 
 
-### <i class="fa-solid fa-gear"></i> Run modelisation
+### <i class="fa-solid fa-gear"></i> Run modeling
 
 #### <i class="fa-solid fa-virus"></i> Single models
 

--- a/vignettes/examples_2_secundaryFunctions.Rmd
+++ b/vignettes/examples_2_secundaryFunctions.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Secundary functions"
+title: "Secondary functions"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Secundary functions}
+  %\VignetteIndexEntry{Secondary functions}
   %\VignetteEngine{knitr::knitr}
   %\VignetteEncoding{UTF-8}
 ---
@@ -12,7 +12,7 @@ vignette: >
 
 ## <i class="fa-solid fa-code"></i> Small code examples
 
-Here are presented, in small and unlinked examples, secundary functions (starting with `bm_[...]`) of `biomod2`. Most of these functions are internally called by some main functions (starting with `BIOMOD_[...]`) of `biomod2`, but can be easily used as such.
+Here are presented, in small and unlinked examples, secondary functions (starting with `bm_[...]`) of `biomod2`. Most of these functions are internally called by some main functions (starting with `BIOMOD_[...]`) of `biomod2`, but can be easily used as such.
 
 
 <br/><br/>
@@ -129,7 +129,7 @@ myResp.real.raster[cellFromXY(myResp.real.raster, myCoord.real.1)] <- 1
 <br/><br/>
 
 
-### <i class="fa-solid fa-square-check"></i> Secundary functions : vector data
+### <i class="fa-solid fa-square-check"></i> Secondary functions : vector data
 
 #### <i class="fa-solid fa-scissors"></i> Generate calibration / evaluation datasets
 
@@ -173,7 +173,7 @@ cbind(vec.d, vec.d_bin, vec.d_filt)
 <br/><br/>
 
 
-### <i class="fa-solid fa-square-check"></i> Secundary functions : explanatory variables
+### <i class="fa-solid fa-square-check"></i> Secondary functions : explanatory variables
 
 #### <i class="fa-solid fa-subscript"></i> Generate automatic formula
 
@@ -229,7 +229,7 @@ bm_VariablesImportance(bm.model = mod,
 <br/><br/>
 
 
-### <i class="fa-solid fa-square-check"></i> Secundary functions : `biomod2` data
+### <i class="fa-solid fa-square-check"></i> Secondary functions : `biomod2` data
 
 ```R
 # Format Data with true absences

--- a/vignettes/vignette_Abundance.Rmd
+++ b/vignettes/vignette_Abundance.Rmd
@@ -163,7 +163,7 @@ The tuning option are not available yet with non binary data.
 <br/><br/>
 
 
-### <i class="fa-solid fa-desktop"></i> Run modelisation
+### <i class="fa-solid fa-desktop"></i> Run modeling
 
 #### <i class="fa-solid fa-cube"></i> Single models
 

--- a/vignettes/vignette_crossValidation.Rmd
+++ b/vignettes/vignette_crossValidation.Rmd
@@ -81,7 +81,7 @@ You will obtain as many ensemble models as cross-validation split, and thus as m
 
 </br>
 
-### &#10012; Concretly
+### &#10012; Concretely
 
 _All the examples are made with the data of the package._ <br/> 
 _For the beginning of the code, see the [main functions vignette](examples_1_mainFunctions.html)._

--- a/vignettes/vignette_dataPreparation.Rmd
+++ b/vignettes/vignette_dataPreparation.Rmd
@@ -10,7 +10,7 @@ vignette: >
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
 
 
-## <i class="fa-solid fa-circle-question"></i> Small preliminar questions
+## <i class="fa-solid fa-circle-question"></i> Small preliminary questions
 
 `biomod2` functions, as any statistical function, will run *as long as the data provided matches the functions requirements*, e.g. coordinate points associated with variable values.
 BUT **the reliability of the data and the assumptions behind it** mostly depend on the attention of the modeler.
@@ -68,7 +68,7 @@ Here are some questions that one's modeler should ask himself before starting hi
 
 **Outliers :** *are some points really distant from the others ? if yes, why ?*
 
-In example 1), the main repartition of the species seem to be in northern Europe, but some points occur in South Africa. It will be good to check if these points are correct, or due to error in coordinates or sampling.
+In example 1), the main distribution of the species seem to be in northern Europe, but some points occur in South Africa. It will be good to check if these points are correct, or due to error in coordinates or sampling.
 
 <br/>
 
@@ -104,7 +104,7 @@ For example, western green lizard (*Lacerta bilineata*) is found (according to W
 - the edges of woods,
 - shrubland, open grassland, arable land, and pastureland.
 
-**Representativity :** *do the available variables reflect these preferences ?*
+**Representativeness :** *do the available variables reflect these preferences ?*
 
 If *precipitations* could reflect the humidity of habitats, variables such as "*is the environment open or closed*", or *percentage of habitat types* would be a plus. However, are those variables available, and at which resolution ? On the contrary, *slope* or *soil type* would be non-interesting here for this species.
 

--- a/vignettes/vignette_presentation.Rmd
+++ b/vignettes/vignette_presentation.Rmd
@@ -28,9 +28,9 @@ vignette: >
 
 
 
-#### <i class="fa-solid fa-list-check"></i> Data formating : [BIOMOD_FormatingData](../reference/BIOMOD_FormatingData.html)
+#### <i class="fa-solid fa-list-check"></i> Data formatting : [BIOMOD_FormatingData](../reference/BIOMOD_FormatingData.html)
 
-- **Formating data** : combine observations, coordinates and explanatory variables, <br/>and sample pseudo-absences for presence-only data (*through [bm_PseudoAbsences](../reference/bm_PseudoAbsences.html)*)
+- **Formatting data** : combine observations, coordinates and explanatory variables, <br/>and sample pseudo-absences for presence-only data (*through [bm_PseudoAbsences](../reference/bm_PseudoAbsences.html)*)
 
 - **Cross-validation** : create calibration / validation datasets (*through [bm_CrossValidation](../reference/bm_CrossValidation.html)*)
 

--- a/vignettes/vignette_pseudoAbsences.Rmd
+++ b/vignettes/vignette_pseudoAbsences.Rmd
@@ -77,7 +77,7 @@ Results were varying between modelling techniques :
 - MARS, MDA : averaging several runs with relatively fewer PA (100) with presences and absences weighted equally
 - CTA, BRT, RF : same amount of PA as available presences
 
-`biomod2` team advices :
+advice from `biomod2`'s team:
 
 - random selection of PA when high specificity is valued over high sensitivity
 - number of PA = 3 times the number of presences

--- a/vignettes/vignette_variability.Rmd
+++ b/vignettes/vignette_variability.Rmd
@@ -17,7 +17,7 @@ When modelling species distribution, there is most of the time an **uncertainty*
 - the *fundamental niche* is most of the time unknown
 - and there might be an uncertainty in the *realized niche*, except in the case of an exhaustive sampling.
 
-What can be evaluated is how much the modelisation results are **consistent** with what is known and observed, and how much **variability** is present in the results in function of modelling choices.
+What can be evaluated is how much the modeling results are **consistent** with what is known and observed, and how much **variability** is present in the results in function of modelling choices.
 
 </br>
 
@@ -26,7 +26,7 @@ What can be evaluated is how much the modelisation results are **consistent** wi
 
 Single and ensemble models can be evaluated by several available evaluation metrics, and the importance of variables can be calculated through several repetitions (see `metric.eval` and `var.import` parameters in [`BIOMOD_Modeling`](../reference/BIOMOD_Modeling.html) and [`BIOMOD_EnsembleModeling`](../reference/BIOMOD_EnsembleModeling.html)).
 
-Variability in evaluation and importance values can come from the parametrisation of different elements of the modelling :
+Variability in evaluation and importance values can come from the parametrization of different elements of the modelling :
 
 - **observed dataset**, 
     + through the number of repetitions of calibration / validation splitting, 


### PR DESCRIPTION
Hey there :)

Just a small PR to correct some typos I found using the `spelling` package. It checks only individual words and not actual sentences and paragraphs. So there could be room to a longer proofreading or checking with a better spellchecker.