### PR TITLE
Fix: correct link to README logo and remove script tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ z-index: 10;
 
 
 <div align="center">
-<p><img src="articles/pictures/LogoBiomod.png" alt="Logo biomod2" width=150px></img></p>
+<p><img src="docs/articles/pictures/LogoBiomod.png" alt="Logo biomod2" width=150px></img></p>
 
 <b>------------------------------------------------------------<br/>
 Species distribution modeling, <br/>

--- a/README.md
+++ b/README.md
@@ -9,20 +9,6 @@ badge for github version :
 badger::badge_github_version("biomodhub/biomod2", "blue") 
 -->
 
-<style>
-.zoom p {
-width:800px;
-margin-left: auto;
-margin-right: auto;
-}
-.zoom p:hover {
-width:1500px;
-position: relative;
-z-index: 10;
-}
-</style>
-
-
 <div align="center">
 <p><img src="docs/articles/pictures/LogoBiomod.png" alt="Logo biomod2" width=150px></img></p>
 


### PR DESCRIPTION
Minor fixes of readme:

- Correct link to readme logo (added docs/ to path)
- Removed script tag from readme since Github won't allow it to have any affect